### PR TITLE
Add note to documentation on client closing SSE connections

### DIFF
--- a/core/lib/src/response/stream/sse.rs
+++ b/core/lib/src/response/stream/sse.rs
@@ -454,7 +454,7 @@ impl Event {
 ///    Alternatively, as described before, use SSE as a notifier which alerts
 ///    the client to fetch the data from elsewhere.
 ///
-///  * **Raw SSE is Lossy**
+///  * **Raw SSE is lossy**
 ///
 ///    Data sent via SSE cannot contain new lines `\n` or carriage returns `\r`
 ///    due to interference with the line protocol.
@@ -475,6 +475,14 @@ impl Event {
 ///
 ///    To send messages losslessly, they must be encoded first, for instance, by
 ///    using [`Event::json()`].
+/// 
+///  * **Clients manage closing connections**
+///
+///    In the [SSE Standard] it is stipulated that clients will reconnect if the
+///    connection is closed and will only stop reconnecting if they receive a 
+///    `HTTP 204 No Content` response code (or close the connection themselves).
+///
+///    [SSE standard]: https://html.spec.whatwg.org/multipage/server-sent-events.html
 pub struct EventStream<S> {
     stream: S,
     heartbeat: Option<Duration>,


### PR DESCRIPTION
Minor documentation addition for SSE management.

For context, we had an event stream tied to a resource. When the resource ceased existing we returned from the EventSource loop in the expectation that the connection would drop. Even monitored for the 'closed' condition in the client so we could clean up stale EventSource objects.

However, a few hours running like this we had 100's of continuously incoming connections which were generating `404 Not Found` rather than the `204 No Content`. The browser was not handling it too well.