### PR TITLE
Make '#[allow(private_bounds)]' compiler version-aware

### DIFF
--- a/core/codegen/src/derive/from_form.rs
+++ b/core/codegen/src/derive/from_form.rs
@@ -120,12 +120,9 @@ pub fn derive_from_form(input: proc_macro::TokenStream) -> TokenStream {
                 let (ctxt_ty, gen) = context_type(input)?;
                 let (impl_gen, _, where_clause)  = gen.split_for_impl();
                 let output = mapper::input_default(mapper, input)?;
-                Ok(quote_spanned! { mixed(input.span()) =>
+                Ok(quote_spanned! { mixed(input.span())=>
                     /// Rocket generated FormForm context.
                     #[doc(hidden)]
-                    #[allow(unknown_lints)]
-                    #[allow(renamed_and_removed_lints)]
-                    #[allow(private_in_public)]
                     #[allow(private_bounds)]
                     #vis struct #ctxt_ty #impl_gen #where_clause {
                         __opts: #_form::Options,


### PR DESCRIPTION
The current fix for #2608 as implemented in e7ef93be495793ba570f13e43772ddff895b644c addressed the problem by introducing both the new `private_bounds` lint rule and the deprecated `private_in_public` one. To smooth out the cross-version incompatibilities, @SergioBenitez added two more lint rules, namely `renamed_and_removed_lints` and `unknown_lints`, to suppress the warnings on both old and new `rustc`s.

https://github.com/rwf2/Rocket/blob/b3abc760aee8556f5b455f13aaa4a1c7ae70bd85/core/codegen/src/derive/from_form.rs#L123-L131

However, we can take one step further by utilizing `version_check` dependency. This PR proposes that the said crate checks the availability of `private_bounds` at codegen time, allowing for fewer lint rules generated in the AST.

The fix is implemented by introducing an auxiliary variable `lints`, which expands to different attributes of lint rules when compiled on different versions of `rustc`. When `rustc` is newer than `1.74.0`, it is set to the token stream of `#[allow(private_bounds)]`, utilizing the new feature; otherwise it is equal to the old sequence of `#[allow(...)]` rules. The need for `#[allow(unknown_lints)]` is eliminated.

**Pros.** Less lint rules generated while retaining the effect of the fix in e7ef93be495793ba570f13e43772ddff895b644c.

**Cons.** None known to the author.

Feel free to make comments and suggest edits to this PR! 👋 