### PR TITLE
updates MSRV to 1.66 for dyn_templates

### DIFF
--- a/contrib/dyn_templates/Cargo.toml
+++ b/contrib/dyn_templates/Cargo.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 keywords = ["rocket", "framework", "templates", "templating", "engine"]
 license = "MIT OR Apache-2.0"
 edition = "2021"
-rust-version = "1.64"
+rust-version = "1.66"
 
 [features]
 tera = ["tera_"]


### PR DESCRIPTION
Handlebars 5 bumped the [MSRV to 1.66](https://github.com/sunng87/handlebars-rust/pull/605)
