### PR TITLE
Add support for routes matching any method

### DIFF
--- a/core/codegen/src/http_codegen.rs
+++ b/core/codegen/src/http_codegen.rs
@@ -97,12 +97,12 @@ impl ToTokens for MediaType {
 }
 
 const VALID_METHODS_STR: &str = "`GET`, `PUT`, `POST`, `DELETE`, `HEAD`, \
-    `PATCH`, `OPTIONS`";
+    `PATCH`, `OPTIONS`, `ANY`";
 
 const VALID_METHODS: &[http::Method] = &[
     http::Method::Get, http::Method::Put, http::Method::Post,
     http::Method::Delete, http::Method::Head, http::Method::Patch,
-    http::Method::Options,
+    http::Method::Options, http::Method::Any,
 ];
 
 impl FromMeta for Method {

--- a/core/codegen/src/lib.rs
+++ b/core/codegen/src/lib.rs
@@ -118,6 +118,9 @@ macro_rules! route_attribute {
         ///   * [`options`] - `OPTIONS` specific route
         ///   * [`patch`] - `PATCH` specific route
         ///
+        /// There is also [`any`] route attribute allowing you to create a
+        /// route matching all methods.
+        ///
         /// Additionally, [`route`] allows the method and uri to be explicitly
         /// specified:
         ///
@@ -137,6 +140,7 @@ macro_rules! route_attribute {
         /// [`head`]: attr.head.html
         /// [`options`]: attr.options.html
         /// [`patch`]: attr.patch.html
+        /// [`any`]: attr.any.html
         /// [`route`]: attr.route.html
         ///
         /// # Grammar
@@ -173,6 +177,8 @@ macro_rules! route_attribute {
         /// ```text
         /// generic-route := METHOD ',' 'uri' '=' route
         /// ```
+        ///
+        /// Here `METHOD` is a supported HTTP method or `ANY`.
         ///
         /// # Typing Requirements
         ///
@@ -286,6 +292,7 @@ route_attribute!(delete => Method::Delete);
 route_attribute!(head => Method::Head);
 route_attribute!(patch => Method::Patch);
 route_attribute!(options => Method::Options);
+route_attribute!(any => Method::Any);
 
 /// Attribute to generate a [`Catcher`] and associated metadata.
 ///

--- a/core/codegen/tests/route.rs
+++ b/core/codegen/tests/route.rs
@@ -175,6 +175,9 @@ fn test_full_route() {
     assert_eq!(response.into_string().unwrap(), format!("({}, {}, {}, {}, {}, {}) ({})",
             sky, name.percent_decode().unwrap(), "A A", "inside", path, simple, expected_uri));
 
+    let response = client.post(format!("/3{}", uri)).body(simple).dispatch();
+    assert_eq!(response.status(), Status::NotFound);
+
     let response = client
         .post(format!("/3{}", uri))
         .header(ContentType::JSON)
@@ -183,6 +186,9 @@ fn test_full_route() {
 
     assert_eq!(response.into_string().unwrap(), format!("({}, {}, {}, {}, {}, {}) ({})",
             sky, name.percent_decode().unwrap(), "A A", "inside", path, simple, expected_uri));
+
+    let response = client.post(format!("/4{}", uri)).body(simple).dispatch();
+    assert_eq!(response.status(), Status::NotFound);
 
     let response = client
         .post(format!("/4{}", uri))

--- a/core/codegen/tests/route.rs
+++ b/core/codegen/tests/route.rs
@@ -176,15 +176,6 @@ fn test_full_route() {
             sky, name.percent_decode().unwrap(), "A A", "inside", path, simple, expected_uri));
 
     let response = client
-        .post(format!("/2{}", uri))
-        .header(ContentType::JSON)
-        .body(simple)
-        .dispatch();
-
-    assert_eq!(response.into_string().unwrap(), format!("({}, {}, {}, {}, {}, {}) ({})",
-            sky, name.percent_decode().unwrap(), "A A", "inside", path, simple, expected_uri));
-
-    let response = client
         .post(format!("/3{}", uri))
         .header(ContentType::JSON)
         .body(simple)

--- a/core/http/src/method.rs
+++ b/core/http/src/method.rs
@@ -47,7 +47,9 @@ pub enum Method {
     /// The `CONNECT` variant.
     Connect,
     /// The `PATCH` variant.
-    Patch
+    Patch,
+    /// A wildcard variant meant to accept any method
+    Any = u8::MAX,
 }
 
 impl Method {
@@ -57,6 +59,9 @@ impl Method {
     /// The following methods always support payloads:
     ///
     ///   * `PUT`, `POST`, `DELETE`, `PATCH`
+    ///
+    /// In addition, the wildcard variant Any is considered to support payloads
+    /// because some methods it matches do.
     ///
     /// The following methods _do not_ always support payloads:
     ///
@@ -74,7 +79,7 @@ impl Method {
     #[inline]
     pub fn supports_payload(self) -> bool {
         match self {
-            Put | Post | Delete | Patch => true,
+            Put | Post | Delete | Patch | Any => true,
             Get | Head | Connect | Trace | Options => false,
         }
     }
@@ -101,6 +106,7 @@ impl Method {
             Trace => "TRACE",
             Connect => "CONNECT",
             Patch => "PATCH",
+            Any => "ANY",
         }
     }
 }
@@ -121,6 +127,7 @@ impl FromStr for Method {
             x if uncased::eq(x, Trace.as_str()) => Ok(Trace),
             x if uncased::eq(x, Connect.as_str()) => Ok(Connect),
             x if uncased::eq(x, Patch.as_str()) => Ok(Patch),
+            x if uncased::eq(x, Any.as_str()) => Ok(Any),
             _ => Err(()),
         }
     }

--- a/core/lib/src/lifecycle.rs
+++ b/core/lib/src/lifecycle.rs
@@ -70,7 +70,9 @@ impl Rocket<Orbit> {
                 .and_then(|field| field.value.parse().ok());
 
             if let Some(method) = method {
-                req.set_method(method);
+                if method != Method::Any {
+                    req.set_method(method);
+                }
             }
         }
 

--- a/core/lib/src/request/atomic_method.rs
+++ b/core/lib/src/request/atomic_method.rs
@@ -14,6 +14,7 @@ const fn makeref(method: Method) -> &'static Method {
         Method::Trace => &Method::Trace,
         Method::Connect => &Method::Connect,
         Method::Patch => &Method::Patch,
+        Method::Any => &Method::Any,
     }
 }
 

--- a/core/lib/src/router/collider.rs
+++ b/core/lib/src/router/collider.rs
@@ -1,7 +1,7 @@
 use crate::catcher::Catcher;
 use crate::route::{Route, Segment, RouteUri};
 
-use crate::http::MediaType;
+use crate::http::{MediaType, Method};
 
 pub trait Collide<T = Self> {
     fn collides_with(&self, other: &T) -> bool;
@@ -87,7 +87,11 @@ impl Route {
     /// assert!(a.collides_with(&b));
     /// ```
     pub fn collides_with(&self, other: &Route) -> bool {
-        self.method == other.method
+        (
+            self.method == Method::Any
+                || other.method == Method::Any
+                || self.method == other.method
+        )
             && self.rank == other.rank
             && self.uri.collides_with(&other.uri)
             && formats_collide(self, other)
@@ -214,7 +218,7 @@ mod tests {
 
     use super::*;
     use crate::route::{Route, dummy_handler};
-    use crate::http::{Method, Method::*, MediaType};
+    use crate::http::{Method::*, MediaType};
 
     fn dummy_route(ranked: bool, method: impl Into<Option<Method>>, uri: &'static str) -> Route {
         let method = method.into().unwrap_or(Get);

--- a/core/lib/src/router/matcher.rs
+++ b/core/lib/src/router/matcher.rs
@@ -1,6 +1,6 @@
 use crate::{Route, Request, Catcher};
 use crate::router::Collide;
-use crate::http::Status;
+use crate::http::{Method, Status};
 use crate::route::Color;
 
 impl Route {
@@ -66,7 +66,7 @@ impl Route {
     /// assert!(b.rank < a.rank);
     /// ```
     pub fn matches(&self, request: &Request<'_>) -> bool {
-        self.method == request.method()
+        (self.method == Method::Any || self.method == request.method())
             && paths_match(self, request)
             && queries_match(self, request)
             && formats_match(self, request)


### PR DESCRIPTION
This implements the change proposed in #2731.

Note that technically this allows invalid requests with `Method::Any` to be created manually. Such requests merely won’t be created automatically by either `Request::from_hyp` or `Rocket::preprocess`. I don’t consider that an issue but your mileage might vary.