### PR TITLE
Minijinja2: Improve error reporting

### DIFF
--- a/contrib/dyn_templates/src/engine/minijinja.rs
+++ b/contrib/dyn_templates/src/engine/minijinja.rs
@@ -43,13 +43,25 @@ impl Engine for Environment<'static> {
     }
 
     fn render<C: Serialize>(&self, name: &str, context: C) -> Option<String> {
-        let Ok(template) = self.get_template(name) else {
-            error_!("Minijinja template '{name}' was not found.");
-            return None;
+        let template = match self.get_template(name) {
+            Ok(template) => template,
+            Err(e) => {
+                error_!("Minijinja template '{name}': {:#}", e);
+                return None;
+            }
         };
 
-        template.render(context)
-            .map_err(|e| error_!("Minijinja: {}", e))
-            .ok()
+        match template.render(context) {
+            Ok(result) => Some(result),
+            Err(e) => {
+                error_!("Minijinja template '{name}': {:#}", e);
+                let mut err = &e as &dyn std::error::Error;
+                while let Some(next_err) = err.source() {
+                    error_!("caused by: {:#}", next_err);
+                    err = next_err;
+                }
+                None
+            }
+        }
     }
 }


### PR DESCRIPTION
This change improves the error reporting for Minijinja2 templates.

Currently, when errors occur in a Minijinja2 template, it usually gives an error message that only has a top-level explanation of the problem. When the issue comes from an included file or a layout, this error message does not include enough details to diagnose the problem when the problem.

With this change, it now prints details about the entire error chain returned, which acts as a stack trace to find the cause of the error.

It also adds the error message on 'template not found' errors. 