### PR TITLE
Implement rewrite API

### DIFF
--- a/core/http/src/uri/segments.rs
+++ b/core/http/src/uri/segments.rs
@@ -218,6 +218,8 @@ impl<'a> Segments<'a, Path> {
         for segment in self.clone() {
             if segment == ".." {
                 buf.pop();
+            } else if segment == "." {
+                continue;
             } else if !allow_dotfiles && segment.starts_with('.') {
                 return Err(PathError::BadStart('.'))
             } else if segment.starts_with('*') {

--- a/core/http/src/uri/segments.rs
+++ b/core/http/src/uri/segments.rs
@@ -178,8 +178,9 @@ impl<'a> Segments<'a, Path> {
     }
 
     /// Creates a `PathBuf` from `self`. The returned `PathBuf` is
-    /// percent-decoded. If a segment is equal to `..`, the previous segment (if
-    /// any) is skipped.
+    /// percent-decoded and guaranteed to be relative. If a segment is equal to
+    /// `.`, it is skipped. If a segment is equal to `..`, the previous segment
+    /// (if any) is skipped.
     ///
     /// For security purposes, if a segment meets any of the following
     /// conditions, an `Err` is returned indicating the condition met:
@@ -193,7 +194,7 @@ impl<'a> Segments<'a, Path> {
     /// Additionally, if `allow_dotfiles` is `false`, an `Err` is returned if
     /// the following condition is met:
     ///
-    ///   * Decoded segment starts with any of: `.` (except `..`)
+    ///   * Decoded segment starts with any of: `.` (except `..` and `.`)
     ///
     /// As a result of these conditions, a `PathBuf` derived via `FromSegments`
     /// is safe to interpolate within, or use as a suffix of, a path without
@@ -216,10 +217,10 @@ impl<'a> Segments<'a, Path> {
     pub fn to_path_buf(&self, allow_dotfiles: bool) -> Result<PathBuf, PathError> {
         let mut buf = PathBuf::new();
         for segment in self.clone() {
-            if segment == ".." {
-                buf.pop();
-            } else if segment == "." {
+            if segment == "." {
                 continue;
+            } else if segment == ".." {
+                buf.pop();
             } else if !allow_dotfiles && segment.starts_with('.') {
                 return Err(PathError::BadStart('.'))
             } else if segment.starts_with('*') {

--- a/core/http/src/uri/segments.rs
+++ b/core/http/src/uri/segments.rs
@@ -245,39 +245,6 @@ impl<'a> Segments<'a, Path> {
 
         Ok(buf)
     }
-
-    /// Similar to `to_path_buf`, but always allows dotfiles, and reports whether
-    /// the path contains dotfiles.
-    pub fn to_path_buf_dotfiles(&self) -> Result<(PathBuf, bool), PathError> {
-        let mut buf = PathBuf::new();
-        let mut is_dotfile = false;
-        for segment in self.clone() {
-            if segment == ".." {
-                buf.pop();
-            } else if segment.starts_with('.') {
-                buf.push(segment);
-                is_dotfile = true;
-            } else if segment.starts_with('*') {
-                return Err(PathError::BadStart('*'))
-            } else if segment.ends_with(':') {
-                return Err(PathError::BadEnd(':'))
-            } else if segment.ends_with('>') {
-                return Err(PathError::BadEnd('>'))
-            } else if segment.ends_with('<') {
-                return Err(PathError::BadEnd('<'))
-            } else if segment.contains('/') {
-                return Err(PathError::BadChar('/'))
-            } else if cfg!(windows) && segment.contains('\\') {
-                return Err(PathError::BadChar('\\'))
-            } else if cfg!(windows) && segment.contains(':') {
-                return Err(PathError::BadChar(':'))
-            } else {
-                buf.push(segment)
-            }
-        }
-
-        Ok((buf, is_dotfile))
-    }
 }
 
 impl<'a> Segments<'a, Query> {

--- a/core/http/src/uri/segments.rs
+++ b/core/http/src/uri/segments.rs
@@ -245,6 +245,39 @@ impl<'a> Segments<'a, Path> {
 
         Ok(buf)
     }
+
+    /// Similar to `to_path_buf`, but always allows dotfiles, and reports whether
+    /// the path contains dotfiles.
+    pub fn to_path_buf_dotfiles(&self) -> Result<(PathBuf, bool), PathError> {
+        let mut buf = PathBuf::new();
+        let mut is_dotfile = false;
+        for segment in self.clone() {
+            if segment == ".." {
+                buf.pop();
+            } else if segment.starts_with('.') {
+                buf.push(segment);
+                is_dotfile = true;
+            } else if segment.starts_with('*') {
+                return Err(PathError::BadStart('*'))
+            } else if segment.ends_with(':') {
+                return Err(PathError::BadEnd(':'))
+            } else if segment.ends_with('>') {
+                return Err(PathError::BadEnd('>'))
+            } else if segment.ends_with('<') {
+                return Err(PathError::BadEnd('<'))
+            } else if segment.contains('/') {
+                return Err(PathError::BadChar('/'))
+            } else if cfg!(windows) && segment.contains('\\') {
+                return Err(PathError::BadChar('\\'))
+            } else if cfg!(windows) && segment.contains(':') {
+                return Err(PathError::BadChar(':'))
+            } else {
+                buf.push(segment)
+            }
+        }
+
+        Ok((buf, is_dotfile))
+    }
 }
 
 impl<'a> Segments<'a, Query> {

--- a/core/lib/src/fs/mod.rs
+++ b/core/lib/src/fs/mod.rs
@@ -34,7 +34,7 @@ crate::export! {
     ///
     /// #[launch]
     /// fn rocket() -> _ {
-    ///     rocket::build().mount("/", FileServer::from(relative!("static")))
+    ///     rocket::build().mount("/", FileServer::new(relative!("static")))
     /// }
     /// ```
     ///

--- a/core/lib/src/fs/mod.rs
+++ b/core/lib/src/fs/mod.rs
@@ -11,7 +11,6 @@ pub use server::*;
 pub use named_file::*;
 pub use temp_file::*;
 pub use file_name::*;
-pub use rewrite::{Rewrite, Rewriter};
 
 crate::export! {
     /// Generates a crate-relative version of a path.

--- a/core/lib/src/fs/mod.rs
+++ b/core/lib/src/fs/mod.rs
@@ -5,6 +5,8 @@ mod named_file;
 mod temp_file;
 mod file_name;
 
+pub mod rewrite;
+
 pub use server::*;
 pub use named_file::*;
 pub use temp_file::*;

--- a/core/lib/src/fs/mod.rs
+++ b/core/lib/src/fs/mod.rs
@@ -11,6 +11,7 @@ pub use server::*;
 pub use named_file::*;
 pub use temp_file::*;
 pub use file_name::*;
+pub use rewrite::{Rewrite, Rewriter};
 
 crate::export! {
     /// Generates a crate-relative version of a path.

--- a/core/lib/src/fs/mod.rs
+++ b/core/lib/src/fs/mod.rs
@@ -11,4 +11,53 @@ pub use server::*;
 pub use named_file::*;
 pub use temp_file::*;
 pub use file_name::*;
-pub use server::relative;
+
+crate::export! {
+    /// Generates a crate-relative version of a path.
+    ///
+    /// This macro is primarily intended for use with [`FileServer`] to serve
+    /// files from a path relative to the crate root.
+    ///
+    /// The macro accepts one parameter, `$path`, an absolute or (preferably)
+    /// relative path. It returns a path as an `&'static str` prefixed with the
+    /// path to the crate root. Use `Path::new(relative!($path))` to retrieve an
+    /// `&'static Path`.
+    ///
+    /// # Example
+    ///
+    /// Serve files from the crate-relative `static/` directory:
+    ///
+    /// ```rust
+    /// # #[macro_use] extern crate rocket;
+    /// use rocket::fs::{FileServer, relative};
+    ///
+    /// #[launch]
+    /// fn rocket() -> _ {
+    ///     rocket::build().mount("/", FileServer::from(relative!("static")))
+    /// }
+    /// ```
+    ///
+    /// Path equivalences:
+    ///
+    /// ```rust
+    /// use std::path::Path;
+    ///
+    /// use rocket::fs::relative;
+    ///
+    /// let manual = Path::new(env!("CARGO_MANIFEST_DIR")).join("static");
+    /// let automatic_1 = Path::new(relative!("static"));
+    /// let automatic_2 = Path::new(relative!("/static"));
+    /// assert_eq!(manual, automatic_1);
+    /// assert_eq!(automatic_1, automatic_2);
+    /// ```
+    ///
+    macro_rules! relative {
+        ($path:expr) => {
+            if cfg!(windows) {
+                concat!(env!("CARGO_MANIFEST_DIR"), "\\", $path)
+            } else {
+                concat!(env!("CARGO_MANIFEST_DIR"), "/", $path)
+            }
+        };
+    }
+}

--- a/core/lib/src/fs/rewrite.rs
+++ b/core/lib/src/fs/rewrite.rs
@@ -1,0 +1,329 @@
+use std::borrow::Cow;
+use std::path::Path;
+
+use crate::{Request, Response};
+use crate::http::{HeaderMap, ContentType};
+use crate::http::ext::IntoOwned;
+use crate::response::{self, Redirect, Responder};
+
+/// Trait used to implement [`FileServer`] customization.
+///
+/// Conceptually, a [`FileServer`] is a sequence of `Rewriter`s, which transform
+/// a path from a request to a final response. [`FileServer`] add a set of default
+/// `Rewriter`s, which filter out dotfiles, apply a root path, normalize directories,
+/// and use `index.html`.
+///
+/// After running the chain of `Rewriter`s,
+/// [`FileServer`] uses the final [`Option<Rewrite>`](Rewrite)
+/// to respond to the request. If the response is `None`, a path that doesn't
+/// exist or a directory path, [`FileServer`] will respond with a
+/// [`Status::NotFound`](crate::http::Status::NotFound). Otherwise the [`FileServer`]
+/// will respond with a redirect or the contents of the file specified.
+///
+/// [`FileServer`] provides several helper methods to add `Rewriter`s:
+/// - [`FileServer::rewrite()`]
+/// - [`FileServer::filter()`]
+/// - [`FileServer::map()`]
+pub trait Rewriter: Send + Sync + 'static {
+    /// Alter the [`Rewrite`] as needed.
+    fn rewrite<'r>(&self, file: Option<Rewrite<'r>>, req: &'r Request<'_>) -> Option<Rewrite<'r>>;
+}
+
+/// A Response from a [`FileServer`]
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+pub enum Rewrite<'r> {
+    /// Return the contents of the specified file.
+    File(File<'r>),
+    /// Returns a Redirect.
+    Redirect(Redirect),
+}
+
+/// A File response from a [`FileServer`]
+#[derive(Debug, Clone)]
+pub struct File<'r> {
+    /// The path to the file that [`FileServer`] will respond with.
+    pub path: Cow<'r, Path>,
+    /// A list of headers to be added to the generated response.
+    pub headers: HeaderMap<'r>,
+}
+
+impl<'r> Rewrite<'r> {
+    pub fn file(&self) -> Option<&File<'r>> {
+        match self {
+            Rewrite::File(f) => Some(f),
+            _ => None,
+        }
+    }
+
+    pub fn redirect(&self) -> Option<&Redirect> {
+        match self {
+            Rewrite::Redirect(r) => Some(r),
+            _ => None,
+        }
+    }
+}
+
+impl<'r> From<File<'r>> for Rewrite<'r> {
+    fn from(value: File<'r>) -> Self {
+        Self::File(value)
+    }
+}
+
+impl<'r> From<Redirect> for Rewrite<'r> {
+    fn from(value: Redirect) -> Self {
+        Self::Redirect(value)
+    }
+}
+
+impl<'r> File<'r> {
+    pub fn new(path: impl Into<Cow<'r, Path>>) -> Self {
+        Self { path: path.into(), headers: HeaderMap::new() }
+    }
+
+    pub(crate) async fn open(self) -> std::io::Result<NamedFile<'r>> {
+        let file = tokio::fs::File::open(&self.path).await?;
+        let metadata = file.metadata().await?;
+        if metadata.is_dir() {
+            return Err(std::io::Error::new(std::io::ErrorKind::Other, "is a directory"));
+        }
+
+        Ok(NamedFile {
+            file,
+            len: metadata.len(),
+            path: self.path,
+            headers: self.headers,
+        })
+    }
+
+    /// Replace the path of this `File`.
+    pub fn map_path<F, P>(self, f: F) -> Self
+        where F: FnOnce(Cow<'r, Path>) -> P,
+              P: Into<Cow<'r, Path>>,
+    {
+        Self {
+            path: f(self.path).into(),
+            headers: self.headers,
+        }
+    }
+}
+
+impl<F: Send + Sync + 'static> Rewriter for F
+    where F: for<'r> Fn(Option<Rewrite<'r>>, &Request<'_>) -> Option<Rewrite<'r>>
+{
+    fn rewrite<'r>(&self, f: Option<Rewrite<'r>>, r: &Request<'_>) -> Option<Rewrite<'r>> {
+        self(f, r)
+    }
+}
+
+impl Rewriter for Rewrite<'static> {
+    fn rewrite<'r>(&self, _: Option<Rewrite<'r>>, _: &Request<'_>) -> Option<Rewrite<'r>> {
+        Some(self.clone())
+    }
+}
+
+impl Rewriter for File<'static> {
+    fn rewrite<'r>(&self, _: Option<Rewrite<'r>>, _: &Request<'_>) -> Option<Rewrite<'r>> {
+        Some(Rewrite::File(self.clone()))
+    }
+}
+
+impl Rewriter for Redirect {
+    fn rewrite<'r>(&self, _: Option<Rewrite<'r>>, _: &Request<'_>) -> Option<Rewrite<'r>> {
+        Some(Rewrite::Redirect(self.clone()))
+    }
+}
+
+/// Helper trait to simplify standard rewrites
+#[doc(hidden)]
+pub trait FileMap: for<'r> Fn(File<'r>, &Request<'_>) -> Rewrite<'r> + Send + Sync + 'static {}
+impl<F> FileMap for F
+    where F: for<'r> Fn(File<'r>, &Request<'_>) -> Rewrite<'r> + Send + Sync + 'static {}
+
+/// Helper trait to simplify standard rewrites
+#[doc(hidden)]
+pub trait FileFilter: Fn(&File<'_>, &Request<'_>) -> bool + Send + Sync + 'static {}
+impl<F> FileFilter for F
+    where F: Fn(&File<'_>, &Request<'_>) -> bool + Send + Sync + 'static {}
+
+/// Prepends the provided path, to serve files from a directory.
+///
+/// You can use [`relative!`] to make a path relative to the crate root, rather
+/// than the runtime directory.
+///
+/// # Example
+///
+/// ```rust,no_run
+/// # use rocket::fs::{FileServer, prefix, relative};
+/// # fn make_server() -> FileServer {
+/// FileServer::empty()
+///     .map(prefix(relative!("static")))
+/// # }
+/// ```
+///
+/// # Panics
+///
+/// Panics if `path` does not exist. See [`file_root_permissive`] for a
+/// non-panicing variant.
+pub fn prefix(path: impl AsRef<Path>) -> impl FileMap {
+    let path = path.as_ref();
+    if !path.is_dir() {
+        let path = path.display();
+        error!(%path, "FileServer path is not a directory.");
+        warn!("Aborting early to prevent inevitable handler error.");
+        panic!("invalid directory: refusing to continue");
+    }
+
+    let path = path.to_path_buf();
+    move |f, _r| {
+        Rewrite::File(f.map_path(|p| path.join(p)))
+    }
+}
+
+/// Prepends the provided path, to serve a single static file.
+///
+/// # Example
+///
+/// ```rust,no_run
+/// # use rocket::fs::{FileServer, file_root};
+/// # fn make_server() -> FileServer {
+/// FileServer::empty()
+///     .map(file_root("static/index.html"))
+/// # }
+/// ```
+///
+/// # Panics
+///
+/// Panics if `path` does not exist. See [`file_root_permissive`] for a
+/// non-panicing variant.
+pub fn file_root(path: impl AsRef<Path>) -> impl Rewriter {
+    let path = path.as_ref();
+    if !path.exists() {
+        let path = path.display();
+        error!(%path, "FileServer path does not exist.");
+        warn!("Aborting early to prevent inevitable handler error.");
+        panic!("invalid file: refusing to continue");
+    }
+
+    Rewrite::File(File::new(path.to_path_buf()))
+}
+
+/// Rewrites the entire path with `path`. Does not check if `path` exists.
+///
+/// # Example
+///
+/// ```rust,no_run
+/// # use rocket::fs::{FileServer, file_root_permissive};
+/// # fn make_server() -> FileServer {
+/// FileServer::empty()
+///     .map(file_root_permissive("/tmp/rocket"))
+/// # }
+/// ```
+pub fn file_root_permissive(path: impl AsRef<Path>) -> impl Rewriter {
+    let path = path.as_ref().to_path_buf();
+    Rewrite::File(File::new(path))
+}
+
+/// Filters out any path that contains a file or directory name starting with a
+/// dot. If used after `prefix`, this will also check the root path for dots, and
+/// filter them.
+///
+/// # Example
+///
+/// ```rust,no_run
+/// # use rocket::fs::{FileServer, filter_dotfiles, prefix};
+/// # fn make_server() -> FileServer {
+/// FileServer::empty()
+///     .filter(filter_dotfiles)
+///     .map(prefix("static"))
+/// # }
+/// ```
+pub fn filter_dotfiles(file: &File<'_>, _req: &Request<'_>) -> bool {
+    !file.path.iter().any(|s| s.as_encoded_bytes().starts_with(b"."))
+}
+
+/// Normalize directory accesses to always include a trailing slash.
+///
+/// # Example
+///
+/// Appends a slash to any request for a directory without a trailing slash
+/// ```rust,no_run
+/// # use rocket::fs::{FileServer, normalize_dirs, prefix};
+/// # fn make_server() -> FileServer {
+/// FileServer::empty()
+///     .map(prefix("static"))
+///     .map(normalize_dirs)
+/// # }
+/// ```
+pub fn normalize_dirs<'r>(file: File<'r>, req: &Request<'_>) -> Rewrite<'r> {
+    if !req.uri().path().ends_with('/') && file.path.is_dir() {
+        // Known good path + '/' is a good path.
+        let uri = req.uri().clone().into_owned();
+        Rewrite::Redirect(Redirect::temporary(uri.map_path(|p| format!("{p}/")).unwrap()))
+    } else {
+        Rewrite::File(file)
+    }
+}
+
+/// Unconditionally rewrite a directory to a file named `index` inside of that
+/// directory.
+///
+/// # Example
+///
+/// Rewrites all directory requests to `directory/index.html`.
+///
+/// ```rust,no_run
+/// # use rocket::fs::{FileServer, index, prefix};
+/// # fn make_server() -> FileServer {
+/// FileServer::empty()
+///     .map(prefix("static"))
+///     .map(index("index.html"))
+/// # }
+/// ```
+pub fn index(index: &'static str) -> impl FileMap {
+    move |f, _r| if f.path.is_dir() {
+        Rewrite::File(f.map_path(|p| p.join(index)))
+    } else {
+        Rewrite::File(f)
+    }
+}
+
+/// Rewrite a directory to a file named `index` inside of that directory if that
+/// file exists. Otherwise, leave the rewrite unchanged.
+pub fn try_index(index: &'static str) -> impl FileMap {
+    move |f, _r| if f.path.is_dir() {
+        let original_path = f.path.clone();
+        let index = original_path.join(index);
+        if index.is_file() {
+            Rewrite::File(f.map_path(|_| index))
+        } else {
+            Rewrite::File(f)
+        }
+    } else {
+        Rewrite::File(f)
+    }
+}
+
+pub(crate) struct NamedFile<'r> {
+    file: tokio::fs::File,
+    len: u64,
+    path: Cow<'r, Path>,
+    headers: HeaderMap<'r>,
+}
+
+// Do we want to allow the user to rewrite the Content-Type?
+impl<'r> Responder<'r, 'r> for NamedFile<'r> {
+    fn respond_to(self, _: &'r Request<'_>) -> response::Result<'r> {
+        let mut response = Response::new();
+        response.set_header_map(self.headers);
+        if !response.headers().contains("Content-Type") {
+            self.path.extension()
+                .and_then(|ext| ext.to_str())
+                .and_then(ContentType::from_extension)
+                .map(|content_type| response.set_header(content_type));
+        }
+
+        response.set_sized_body(self.len as usize, self.file);
+        Ok(response)
+    }
+}

--- a/core/lib/src/fs/rewrite.rs
+++ b/core/lib/src/fs/rewrite.rs
@@ -1,32 +1,29 @@
 use std::borrow::Cow;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
-use crate::{Request, Response};
-use crate::http::{HeaderMap, ContentType};
-use crate::http::ext::IntoOwned;
-use crate::response::{self, Redirect, Responder};
+use crate::Request;
+use crate::http::{ext::IntoOwned, HeaderMap};
+use crate::response::Redirect;
 
 /// Trait used to implement [`FileServer`] customization.
 ///
-/// Conceptually, a [`FileServer`] is a sequence of `Rewriter`s, which transform
-/// a path from a request to a final response. [`FileServer`] add a set of default
-/// `Rewriter`s, which filter out dotfiles, apply a root path, normalize directories,
-/// and use `index.html`.
+/// A [`FileServer`] is a sequence of `Rewriter`s which transform the incoming
+/// request path into a [`Rewrite`] or `None`.
 ///
-/// After running the chain of `Rewriter`s,
-/// [`FileServer`] uses the final [`Option<Rewrite>`](Rewrite)
-/// to respond to the request. If the response is `None`, a path that doesn't
-/// exist or a directory path, [`FileServer`] will respond with a
-/// [`Status::NotFound`](crate::http::Status::NotFound). Otherwise the [`FileServer`]
-/// will respond with a redirect or the contents of the file specified.
+/// If the final rewrite is `None` or a nonexistent path or a directory,
+/// [`FileServer`] responds with [`Status::NotFound`]. Otherwise it responds
+/// with the file contents, if [`Rewrite::File`] is specified, or a redirect, if
+/// [`Rewrite::Redirect`] is specified.
 ///
-/// [`FileServer`] provides several helper methods to add `Rewriter`s:
-/// - [`FileServer::rewrite()`]
-/// - [`FileServer::filter()`]
-/// - [`FileServer::map()`]
+/// # Creating a `FileServer`
+///
+/// The primary way to create a `FileServer` is via [`FileServer::new()`] which
+/// creates a new `FileServer` with a default set of `Rewriter`s: a filter for
+/// dotfiles, a root path to apply as a prefix, an index file rewriter, and a
+/// rewriter to normalize directories to always include a trailing slash.
 pub trait Rewriter: Send + Sync + 'static {
     /// Alter the [`Rewrite`] as needed.
-    fn rewrite<'r>(&self, file: Option<Rewrite<'r>>, req: &'r Request<'_>) -> Option<Rewrite<'r>>;
+    fn rewrite<'r>(&self, opt: Option<Rewrite<'r>>, req: &'r Request<'_>) -> Option<Rewrite<'r>>;
 }
 
 /// A Response from a [`FileServer`]
@@ -39,7 +36,7 @@ pub enum Rewrite<'r> {
     Redirect(Redirect),
 }
 
-/// A File response from a [`FileServer`]
+/// A File response from a [`FileServer`] and a rewriter.
 #[derive(Debug, Clone)]
 pub struct File<'r> {
     /// The path to the file that [`FileServer`] will respond with.
@@ -48,18 +45,166 @@ pub struct File<'r> {
     pub headers: HeaderMap<'r>,
 }
 
-impl<'r> Rewrite<'r> {
-    pub fn file(&self) -> Option<&File<'r>> {
-        match self {
-            Rewrite::File(f) => Some(f),
-            _ => None,
+impl<'r> File<'r> {
+    pub fn new(path: impl Into<Cow<'r, Path>>) -> Self {
+        Self { path: path.into(), headers: HeaderMap::new() }
+    }
+
+    pub fn checked<P: AsRef<Path>>(path: P) -> Self {
+        let path = path.as_ref();
+        if !path.exists() {
+            let path = path.display();
+            error!(%path, "FileServer path does not exist.\n\
+                Panicking to prevent inevitable handler error.");
+            panic!("missing file {}: refusing to continue", path);
+        }
+
+        Self::new(path.to_path_buf())
+    }
+
+    /// Replace the path in `self` with the result of applying `f` to the path.
+    pub fn map_path<F, P>(self, f: F) -> Self
+        where F: FnOnce(Cow<'r, Path>) -> P, P: Into<Cow<'r, Path>>,
+    {
+        Self {
+            path: f(self.path).into(),
+            headers: self.headers,
         }
     }
 
-    pub fn redirect(&self) -> Option<&Redirect> {
-        match self {
-            Rewrite::Redirect(r) => Some(r),
-            _ => None,
+    /// Returns `true` if the file is a dotfile. A dotfile is a file whose name
+    /// starts with a period (`.`) and is considered hidden.
+    pub fn is_hidden(&self) -> bool {
+        self.path.iter().any(|s| s.as_encoded_bytes().starts_with(b"."))
+    }
+
+    /// Returns `true` if the file is not hidden. This is the inverse of
+    /// [`File::is_hidden()`].
+    pub fn is_visible(&self) -> bool {
+        !self.is_hidden()
+    }
+}
+
+/// Prefixes all paths with a given path.
+///
+/// # Example
+///
+/// ```rust,no_run
+/// use rocket::fs::FileServer;
+/// use rocket::fs::rewrite::Prefix;
+///
+/// FileServer::empty()
+///    .filter_file(|f| f.is_visible())
+///    .rewrite(Prefix::checked("static"));
+/// ```
+pub struct Prefix(PathBuf);
+
+impl Prefix {
+    /// Panics if `path` does not exist.
+    pub fn checked<P: AsRef<Path>>(path: P) -> Self {
+        let path = path.as_ref();
+        if !path.is_dir() {
+            let path = path.display();
+            error!(%path, "FileServer path is not a directory.");
+            warn!("Aborting early to prevent inevitable handler error.");
+            panic!("invalid directory: refusing to continue");
+        }
+
+        Self(path.to_path_buf())
+    }
+
+    /// Creates a new `Prefix` from a path.
+    pub fn unchecked<P: AsRef<Path>>(path: P) -> Self {
+        Self(path.as_ref().to_path_buf())
+    }
+}
+
+impl Rewriter for Prefix {
+    fn rewrite<'r>(&self, opt: Option<Rewrite<'r>>, _: &Request<'_>) -> Option<Rewrite<'r>> {
+        opt.map(|r| match r {
+            Rewrite::File(f) => Rewrite::File(f.map_path(|p| self.0.join(p))),
+            Rewrite::Redirect(r) => Rewrite::Redirect(r),
+        })
+    }
+}
+
+impl Rewriter for PathBuf {
+    fn rewrite<'r>(&self, _: Option<Rewrite<'r>>, _: &Request<'_>) -> Option<Rewrite<'r>> {
+        Some(Rewrite::File(File::new(self.clone())))
+    }
+}
+
+/// Normalize directories to always include a trailing slash by redirecting
+/// (with a 302 temporary redirect) requests for directories without a trailing
+/// slash to the same path with a trailing slash.
+///
+/// # Example
+///
+/// ```rust,no_run
+/// use rocket::fs::FileServer;
+/// use rocket::fs::rewrite::{Prefix, TrailingDirs};
+///
+/// FileServer::empty()
+///     .filter_file(|f| f.is_visible())
+///     .rewrite(TrailingDirs);
+/// ```
+pub struct TrailingDirs;
+
+impl Rewriter for TrailingDirs {
+    fn rewrite<'r>(&self, opt: Option<Rewrite<'r>>, req: &Request<'_>) -> Option<Rewrite<'r>> {
+        if let Some(Rewrite::File(f)) = &opt {
+            if !req.uri().path().ends_with('/') && f.path.is_dir() {
+                let uri = req.uri().clone().into_owned();
+                let uri = uri.map_path(|p| format!("{p}/")).unwrap();
+                return Some(Rewrite::Redirect(Redirect::temporary(uri)));
+            }
+        }
+
+        opt
+    }
+}
+
+/// Rewrite a directory to a file inside of that directory.
+///
+/// # Example
+///
+/// Rewrites all directory requests to `directory/index.html`.
+///
+/// ```rust,no_run
+/// use rocket::fs::FileServer;
+/// use rocket::fs::rewrite::DirIndex;
+///
+/// FileServer::directory("static")
+///     .rewrite(DirIndex::if_exists("index.htm"))
+///     .rewrite(DirIndex::unconditional("index.html"));
+/// ```
+pub struct DirIndex {
+    path: PathBuf,
+    check: bool,
+}
+
+impl DirIndex {
+    pub fn unconditional(path: impl AsRef<Path>) -> Self {
+        Self { path: path.as_ref().to_path_buf(), check: false }
+    }
+
+    pub fn if_exists(path: impl AsRef<Path>) -> Self {
+        Self { path: path.as_ref().to_path_buf(), check: true }
+    }
+}
+
+impl Rewriter for DirIndex {
+    fn rewrite<'r>(&self, opt: Option<Rewrite<'r>>, _: &Request<'_>) -> Option<Rewrite<'r>> {
+        match opt? {
+            Rewrite::File(f) if f.path.is_dir() => {
+                let candidate = f.path.join(&self.path);
+                if self.check && !candidate.is_file() {
+                    return Some(Rewrite::File(f));
+                }
+
+                Some(Rewrite::File(f.map_path(|_| candidate)))
+            }
+            r => Some(r),
         }
     }
 }
@@ -73,38 +218,6 @@ impl<'r> From<File<'r>> for Rewrite<'r> {
 impl<'r> From<Redirect> for Rewrite<'r> {
     fn from(value: Redirect) -> Self {
         Self::Redirect(value)
-    }
-}
-
-impl<'r> File<'r> {
-    pub fn new(path: impl Into<Cow<'r, Path>>) -> Self {
-        Self { path: path.into(), headers: HeaderMap::new() }
-    }
-
-    pub(crate) async fn open(self) -> std::io::Result<NamedFile<'r>> {
-        let file = tokio::fs::File::open(&self.path).await?;
-        let metadata = file.metadata().await?;
-        if metadata.is_dir() {
-            return Err(std::io::Error::new(std::io::ErrorKind::Other, "is a directory"));
-        }
-
-        Ok(NamedFile {
-            file,
-            len: metadata.len(),
-            path: self.path,
-            headers: self.headers,
-        })
-    }
-
-    /// Replace the path of this `File`.
-    pub fn map_path<F, P>(self, f: F) -> Self
-        where F: FnOnce(Cow<'r, Path>) -> P,
-              P: Into<Cow<'r, Path>>,
-    {
-        Self {
-            path: f(self.path).into(),
-            headers: self.headers,
-        }
     }
 }
 
@@ -131,199 +244,5 @@ impl Rewriter for File<'static> {
 impl Rewriter for Redirect {
     fn rewrite<'r>(&self, _: Option<Rewrite<'r>>, _: &Request<'_>) -> Option<Rewrite<'r>> {
         Some(Rewrite::Redirect(self.clone()))
-    }
-}
-
-/// Helper trait to simplify standard rewrites
-#[doc(hidden)]
-pub trait FileMap: for<'r> Fn(File<'r>, &Request<'_>) -> Rewrite<'r> + Send + Sync + 'static {}
-impl<F> FileMap for F
-    where F: for<'r> Fn(File<'r>, &Request<'_>) -> Rewrite<'r> + Send + Sync + 'static {}
-
-/// Helper trait to simplify standard rewrites
-#[doc(hidden)]
-pub trait FileFilter: Fn(&File<'_>, &Request<'_>) -> bool + Send + Sync + 'static {}
-impl<F> FileFilter for F
-    where F: Fn(&File<'_>, &Request<'_>) -> bool + Send + Sync + 'static {}
-
-/// Prepends the provided path, to serve files from a directory.
-///
-/// You can use [`relative!`] to make a path relative to the crate root, rather
-/// than the runtime directory.
-///
-/// # Example
-///
-/// ```rust,no_run
-/// # use rocket::fs::{FileServer, prefix, relative};
-/// # fn make_server() -> FileServer {
-/// FileServer::empty()
-///     .map(prefix(relative!("static")))
-/// # }
-/// ```
-///
-/// # Panics
-///
-/// Panics if `path` does not exist. See [`file_root_permissive`] for a
-/// non-panicing variant.
-pub fn prefix(path: impl AsRef<Path>) -> impl FileMap {
-    let path = path.as_ref();
-    if !path.is_dir() {
-        let path = path.display();
-        error!(%path, "FileServer path is not a directory.");
-        warn!("Aborting early to prevent inevitable handler error.");
-        panic!("invalid directory: refusing to continue");
-    }
-
-    let path = path.to_path_buf();
-    move |f, _r| {
-        Rewrite::File(f.map_path(|p| path.join(p)))
-    }
-}
-
-/// Prepends the provided path, to serve a single static file.
-///
-/// # Example
-///
-/// ```rust,no_run
-/// # use rocket::fs::{FileServer, file_root};
-/// # fn make_server() -> FileServer {
-/// FileServer::empty()
-///     .map(file_root("static/index.html"))
-/// # }
-/// ```
-///
-/// # Panics
-///
-/// Panics if `path` does not exist. See [`file_root_permissive`] for a
-/// non-panicing variant.
-pub fn file_root(path: impl AsRef<Path>) -> impl Rewriter {
-    let path = path.as_ref();
-    if !path.exists() {
-        let path = path.display();
-        error!(%path, "FileServer path does not exist.");
-        warn!("Aborting early to prevent inevitable handler error.");
-        panic!("invalid file: refusing to continue");
-    }
-
-    Rewrite::File(File::new(path.to_path_buf()))
-}
-
-/// Rewrites the entire path with `path`. Does not check if `path` exists.
-///
-/// # Example
-///
-/// ```rust,no_run
-/// # use rocket::fs::{FileServer, file_root_permissive};
-/// # fn make_server() -> FileServer {
-/// FileServer::empty()
-///     .map(file_root_permissive("/tmp/rocket"))
-/// # }
-/// ```
-pub fn file_root_permissive(path: impl AsRef<Path>) -> impl Rewriter {
-    let path = path.as_ref().to_path_buf();
-    Rewrite::File(File::new(path))
-}
-
-/// Filters out any path that contains a file or directory name starting with a
-/// dot. If used after `prefix`, this will also check the root path for dots, and
-/// filter them.
-///
-/// # Example
-///
-/// ```rust,no_run
-/// # use rocket::fs::{FileServer, filter_dotfiles, prefix};
-/// # fn make_server() -> FileServer {
-/// FileServer::empty()
-///     .filter(filter_dotfiles)
-///     .map(prefix("static"))
-/// # }
-/// ```
-pub fn filter_dotfiles(file: &File<'_>, _req: &Request<'_>) -> bool {
-    !file.path.iter().any(|s| s.as_encoded_bytes().starts_with(b"."))
-}
-
-/// Normalize directory accesses to always include a trailing slash.
-///
-/// # Example
-///
-/// Appends a slash to any request for a directory without a trailing slash
-/// ```rust,no_run
-/// # use rocket::fs::{FileServer, normalize_dirs, prefix};
-/// # fn make_server() -> FileServer {
-/// FileServer::empty()
-///     .map(prefix("static"))
-///     .map(normalize_dirs)
-/// # }
-/// ```
-pub fn normalize_dirs<'r>(file: File<'r>, req: &Request<'_>) -> Rewrite<'r> {
-    if !req.uri().path().ends_with('/') && file.path.is_dir() {
-        // Known good path + '/' is a good path.
-        let uri = req.uri().clone().into_owned();
-        Rewrite::Redirect(Redirect::temporary(uri.map_path(|p| format!("{p}/")).unwrap()))
-    } else {
-        Rewrite::File(file)
-    }
-}
-
-/// Unconditionally rewrite a directory to a file named `index` inside of that
-/// directory.
-///
-/// # Example
-///
-/// Rewrites all directory requests to `directory/index.html`.
-///
-/// ```rust,no_run
-/// # use rocket::fs::{FileServer, index, prefix};
-/// # fn make_server() -> FileServer {
-/// FileServer::empty()
-///     .map(prefix("static"))
-///     .map(index("index.html"))
-/// # }
-/// ```
-pub fn index(index: &'static str) -> impl FileMap {
-    move |f, _r| if f.path.is_dir() {
-        Rewrite::File(f.map_path(|p| p.join(index)))
-    } else {
-        Rewrite::File(f)
-    }
-}
-
-/// Rewrite a directory to a file named `index` inside of that directory if that
-/// file exists. Otherwise, leave the rewrite unchanged.
-pub fn try_index(index: &'static str) -> impl FileMap {
-    move |f, _r| if f.path.is_dir() {
-        let original_path = f.path.clone();
-        let index = original_path.join(index);
-        if index.is_file() {
-            Rewrite::File(f.map_path(|_| index))
-        } else {
-            Rewrite::File(f)
-        }
-    } else {
-        Rewrite::File(f)
-    }
-}
-
-pub(crate) struct NamedFile<'r> {
-    file: tokio::fs::File,
-    len: u64,
-    path: Cow<'r, Path>,
-    headers: HeaderMap<'r>,
-}
-
-// Do we want to allow the user to rewrite the Content-Type?
-impl<'r> Responder<'r, 'r> for NamedFile<'r> {
-    fn respond_to(self, _: &'r Request<'_>) -> response::Result<'r> {
-        let mut response = Response::new();
-        response.set_header_map(self.headers);
-        if !response.headers().contains("Content-Type") {
-            self.path.extension()
-                .and_then(|ext| ext.to_str())
-                .and_then(ContentType::from_extension)
-                .map(|content_type| response.set_header(content_type));
-        }
-
-        response.set_sized_body(self.len as usize, self.file);
-        Ok(response)
     }
 }

--- a/core/lib/src/fs/server.rs
+++ b/core/lib/src/fs/server.rs
@@ -360,7 +360,8 @@ impl FileServer {
             self.rewrites.push(Arc::new(rewrite));
         } else {
             error!(
-                "Attempted to insert multiple of the same rewrite `{}` on a FileServer",
+                "Attempted to insert multiple of the same rewrite `{}` on a FileServer.\n\
+                Adding a rewrite that doesn't support duplicate rewrites is ignored",
                 rewrite.name()
             );
         }

--- a/core/lib/src/fs/server.rs
+++ b/core/lib/src/fs/server.rs
@@ -128,7 +128,7 @@ pub enum FileServerResponse {
 }
 
 // These might have to remain as basic options (always processed first)
-struct DotFiles;
+pub struct DotFiles;
 impl Rewrite for DotFiles {
     fn rewrite(&self, _req: &Request<'_>, path: FileServerResponse, _root: &Path)
         -> FileServerResponse
@@ -147,7 +147,7 @@ impl Rewrite for DotFiles {
 //     }
 // }
 
-struct Index(&'static str);
+pub struct Index(pub &'static str);
 impl Rewrite for Index {
     fn rewrite(&self, _req: &Request<'_>, path: FileServerResponse, root: &Path)
         -> FileServerResponse
@@ -161,7 +161,7 @@ impl Rewrite for Index {
 }
 // Actually, curiously, this already just works as-is (the only thing that prevents
 // it is the startup check)
-struct IndexFile;
+pub struct IndexFile;
 impl Rewrite for IndexFile {
     fn rewrite(&self, _req: &Request<'_>, path: FileServerResponse, _root: &Path)
         -> FileServerResponse
@@ -172,7 +172,7 @@ impl Rewrite for IndexFile {
     }
 }
 
-struct NormalizeDirs;
+pub struct NormalizeDirs;
 impl Rewrite for NormalizeDirs {
     fn rewrite(&self, req: &Request<'_>, path: FileServerResponse, root: &Path)
         -> FileServerResponse

--- a/core/lib/src/fs/server.rs
+++ b/core/lib/src/fs/server.rs
@@ -353,7 +353,7 @@ pub fn filter_dotfiles(file: &File<'_, '_>) -> bool {
 /// # }
 /// ```
 pub fn normalize_dirs<'p, 'h>(file: File<'p, 'h>) -> FileResponse<'p, 'h> {
-    if !file.full_uri.has_trailing_slash() && file.path.is_dir() {
+    if !file.full_uri.path().raw().ends_with('/') && file.path.is_dir() {
         // Known good path + '/' is a good path
         file.into_redirect(|o| o.map_path(|p| format!("{p}/")).unwrap())
     } else {

--- a/core/lib/src/fs/server.rs
+++ b/core/lib/src/fs/server.rs
@@ -255,7 +255,7 @@ pub fn dir_root(path: impl AsRef<Path>)
     if !path.is_dir() {
         let path = path.display();
         error!("FileServer path '{}' is not a directory.", path.primary());
-        warn_!("Aborting early to prevent inevitable handler error.");
+        warn!("Aborting early to prevent inevitable handler error.");
         panic!("invalid directory: refusing to continue");
     }
     let path = path.to_path_buf();
@@ -288,7 +288,7 @@ pub fn file_root(path: impl AsRef<Path>)
     if !path.exists() {
         let path = path.display();
         error!("FileServer path '{}' is not a file.", path.primary());
-        warn_!("Aborting early to prevent inevitable handler error.");
+        warn!("Aborting early to prevent inevitable handler error.");
         panic!("invalid file: refusing to continue");
     }
     let path = path.to_path_buf();

--- a/core/lib/src/fs/server.rs
+++ b/core/lib/src/fs/server.rs
@@ -1,21 +1,14 @@
-use core::fmt;
-use std::borrow::Cow;
-use std::ffi::OsStr;
-use std::path::{Path, PathBuf, MAIN_SEPARATOR_STR};
+use std::fmt;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
-use crate::fs::NamedFile;
-use crate::{Data, Request, outcome::IntoOutcome};
-use crate::http::{
-    Method,
-    HeaderMap,
-    Header,
-    uri::Segments,
-    Status,
-    ext::IntoOwned,
-};
+use crate::{Data, Request};
+use crate::outcome::IntoOutcome;
+use crate::http::{uri::Segments, Method, Status};
 use crate::route::{Route, Handler, Outcome};
-use crate::response::{Redirect, Responder};
+use crate::response::Responder;
+use crate::util::Formatter;
+use crate::fs::rewrite::*;
 
 /// Custom handler for serving static files.
 ///
@@ -24,18 +17,19 @@ use crate::response::{Redirect, Responder};
 /// [`FileServer::from()`], then simply `mount` the handler. When mounted, the
 /// handler serves files from the specified directory. If the file is not found,
 /// the handler _forwards_ the request. By default, `FileServer` has a rank of
-/// `10`. Use [`FileServer::new()`] to create a route with a custom rank.
+/// `10`. Use [`FileServer::new()`] to create a handler with a custom rank.
 ///
 /// # Customization
 ///
-/// How `FileServer` responds to specific requests can be customized, through
+/// How `FileServer` responds to specific requests can be customized through
 /// the use of [`Rewriter`]s. See [`Rewriter`] for more detailed documentation
-/// on how to take full advantage of the customization of `FileServer`.
+/// on how to take full advantage of `FileServer`'s extensibility.
 ///
-/// [`FileServer::from()`] and [`FileServer::new()`] automatically add some common
-/// rewrites. They filter out dotfiles, redirect folder accesses to include a trailing
-/// slash, and use `index.html` to respond to requests for a directory. If you want
-/// to customize or replace these default rewrites, see [`FileServer::empty()`].
+/// [`FileServer::from()`] and [`FileServer::new()`] construct a `FileServer`
+/// with common rewrites: they filter out dotfiles, redirect requests to
+/// directories to include a trailing slash, and use `index.html` to respond to
+/// requests for a directory. If you want to customize or replace these default
+/// rewrites, see [`FileServer::empty()`].
 ///
 /// # Example
 ///
@@ -79,430 +73,62 @@ pub struct FileServer {
     rank: isize,
 }
 
-impl fmt::Debug for FileServer {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("FileServer")
-            // .field("root", &self.root)
-            .field("rewrites", &DebugListRewrite(&self.rewrites))
-            .field("rank", &self.rank)
-            .finish()
-    }
-}
-
-struct DebugListRewrite<'a>(&'a Vec<Arc<dyn Rewriter>>);
-
-impl fmt::Debug for DebugListRewrite<'_> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "<{} rewrites>", self.0.len())
-    }
-}
-
-/// Trait used to implement [`FileServer`] customization.
-///
-/// Conceptually, a [`FileServer`] is a sequence of `Rewriter`s, which transform
-/// a path from a request to a final response. [`FileServer`] add a set of default
-/// `Rewriter`s, which filter out dotfiles, apply a root path, normalize directories,
-/// and use `index.html`.
-///
-/// After running the chain of `Rewriter`s,
-/// [`FileServer`] uses the final [`Option<FileResponse>`](FileResponse)
-/// to respond to the request. If the response is `None`, a path that doesn't
-/// exist or a directory path, [`FileServer`] will respond with a
-/// [`Status::NotFound`](crate::http::Status::NotFound). Otherwise the [`FileServer`]
-/// will respond with a redirect or the contents of the file specified.
-///
-/// [`FileServer`] provides several helper methods to add `Rewriter`s:
-/// - [`FileServer::and_rewrite()`]
-/// - [`FileServer::filter_file()`]
-/// - [`FileServer::map_file()`]
-pub trait Rewriter: Send + Sync + 'static {
-    /// Alter the [`FileResponse`] as needed.
-    fn rewrite<'p, 'h>(&self, path: Option<FileResponse<'p, 'h>>, req: &Request<'_>)
-        -> Option<FileResponse<'p, 'h>>;
-}
-
-/// A Response from a [`FileServer`]
-#[derive(Debug)]
-#[non_exhaustive]
-pub enum FileResponse<'p, 'h> {
-    /// Return the contents of the specified file.
-    File(File<'p, 'h>),
-    /// Returns a Redirect to the specified path. This needs to be an absolute
-    /// URI, so you should start with [`File.full_uri`](File) when constructing
-    /// a redirect.
-    Redirect(Redirect),
-}
-
-impl<'p, 'h> From<File<'p, 'h>> for FileResponse<'p, 'h> {
-    fn from(value: File<'p, 'h>) -> Self {
-        Self::File(value)
-    }
-}
-impl<'p, 'h> From<File<'p, 'h>> for Option<FileResponse<'p, 'h>> {
-    fn from(value: File<'p, 'h>) -> Self {
-        Some(FileResponse::File(value))
-    }
-}
-
-impl<'p, 'h> From<Redirect> for FileResponse<'p, 'h> {
-    fn from(value: Redirect) -> Self {
-        Self::Redirect(value)
-    }
-}
-impl<'p, 'h> From<Redirect> for Option<FileResponse<'p, 'h>> {
-    fn from(value: Redirect) -> Self {
-        Some(FileResponse::Redirect(value))
-    }
-}
-
-/// A File response from a [`FileServer`]
-#[derive(Debug)]
-pub struct File<'p, 'h> {
-    /// The path to the file that [`FileServer`] will respond with.
-    pub path: Cow<'p, Path>,
-    /// A list of headers to be added to the generated response.
-    pub headers: HeaderMap<'h>,
-}
-
-impl<'p, 'h> File<'p, 'h> {
-    /// Add a header to this `File`.
-    pub fn with_header<'n: 'h, H: Into<Header<'n>>>(mut self, header: H) -> Self {
-        self.headers.add(header);
-        self
-    }
-
-    /// Replace the path of this `File`.
-    pub fn with_path(self, path: impl Into<Cow<'p, Path>>) -> Self {
-        Self {
-            path: path.into(),
-            headers: self.headers,
-        }
-    }
-
-    /// Replace the path of this `File`.
-    pub fn map_path<R: Into<Cow<'p, Path>>>(self, f: impl FnOnce(Cow<'p, Path>) -> R) -> Self {
-        Self {
-            path: f(self.path).into(),
-            headers: self.headers,
-        }
-    }
-
-    // /// Convert this `File` into a Redirect, transforming the URI.
-    // pub fn into_redirect(self, f: impl FnOnce(Origin<'static>) -> Origin<'static>)
-    //     -> FileResponse<'p, 'h>
-    // {
-    //     FileResponse::Redirect(Redirect::permanent(f(self.full_uri.clone().into_owned())))
-    // }
-
-    async fn respond_to<'r>(self, req: &'r Request<'_>, data: Data<'r>) -> Outcome<'r>
-        where 'h: 'r
-    {
-        /// Normalize paths to enable `file_root` to work properly
-        fn strip_trailing_slash(p: &Path) -> &Path {
-            let bytes = p.as_os_str().as_encoded_bytes();
-            let bytes = bytes.strip_suffix(MAIN_SEPARATOR_STR.as_bytes()).unwrap_or(bytes);
-            // SAFETY: Since we stripped a valid UTF-8 sequence (or left it unchanged),
-            // this is still a valid OsStr.
-            Path::new(unsafe { OsStr::from_encoded_bytes_unchecked(bytes) })
-        }
-
-        let path = strip_trailing_slash(self.path.as_ref());
-        // Fun fact, on Linux attempting to open a directory works, it just errors
-        // when you attempt to read it.
-        if path.is_file() {
-            NamedFile::open(path)
-                .await
-                .respond_to(req)
-                .map(|mut r| {
-                    for header in self.headers {
-                        r.adjoin_raw_header(header.name.as_str().to_owned(), header.value);
-                    }
-                    r
-                }).or_forward((data, Status::NotFound))
-        } else {
-            Outcome::forward(data, Status::NotFound)
-        }
-    }
-}
-
-impl<F: Send + Sync + 'static> Rewriter for F
-    where F: for<'r, 'h> Fn(Option<FileResponse<'r, 'h>>, &Request<'_>)
-        -> Option<FileResponse<'r, 'h>>
-{
-    fn rewrite<'p, 'h>(&self, path: Option<FileResponse<'p, 'h>>, req: &Request<'_>)
-        -> Option<FileResponse<'p, 'h>>
-    {
-        self(path, req)
-    }
-}
-
-/// Helper to implement [`FileServer::filter_file()`]
-struct FilterFile<F>(F);
-impl<F> Rewriter for FilterFile<F>
-    where F: Fn(&File<'_, '_>, &Request<'_>) -> bool + Send + Sync + 'static
-{
-    fn rewrite<'p, 'h>(&self, path: Option<FileResponse<'p, 'h>>, req: &Request<'_>)
-        -> Option<FileResponse<'p, 'h>>
-    {
-        match path {
-            Some(FileResponse::File(file)) if !self.0(&file, req) => None,
-            path => path,
-        }
-    }
-}
-
-/// Helper to implement [`FileServer::map_file()`]
-struct MapFile<F>(F);
-impl<F> Rewriter for MapFile<F>
-    where F: for<'p, 'h> Fn(File<'p, 'h>, &Request<'_>)
-        -> FileResponse<'p, 'h> + Send + Sync + 'static,
-{
-    fn rewrite<'p, 'h>(&self, path: Option<FileResponse<'p, 'h>>, req: &Request<'_>)
-        -> Option<FileResponse<'p, 'h>>
-    {
-        match path {
-            Some(FileResponse::File(file)) => Some(self.0(file, req)),
-            path => path,
-        }
-    }
-}
-
-/// Helper trait to simplify standard rewrites
-#[doc(hidden)]
-pub trait FileMap:
-    for<'p, 'h> Fn(File<'p, 'h>, &Request<'_>) -> FileResponse<'p, 'h> + Send + Sync + 'static
-{}
-impl<F> FileMap for F
-    where F: for<'p, 'h> Fn(File<'p, 'h>, &Request<'_>)
-        -> FileResponse<'p, 'h> + Send + Sync + 'static
-{}
-/// Helper trait to simplify standard rewrites
-#[doc(hidden)]
-pub trait FileFilter: Fn(&File<'_, '_>, &Request<'_>) -> bool + Send + Sync + 'static {}
-impl<F> FileFilter for F
-    where F: Fn(&File<'_, '_>, &Request<'_>) -> bool + Send + Sync + 'static
-{}
-
-/// Prepends the provided path, to serve files from a directory.
-///
-/// You can use [`relative!`] to make a path relative to the crate root, rather
-/// than the runtime directory.
-///
-/// # Example
-///
-/// ```rust,no_run
-/// # use rocket::fs::{FileServer, dir_root, relative};
-/// # fn make_server() -> FileServer {
-/// FileServer::empty()
-///     .map_file(dir_root(relative!("static")))
-/// # }
-/// ```
-///
-/// # Panics
-///
-/// Panics if `path` does not exist. See [`file_root_permissive`] for a
-/// non-panicing variant.
-pub fn dir_root(path: impl AsRef<Path>) -> impl FileMap {
-    let path = path.as_ref();
-    if !path.is_dir() {
-        let path = path.display();
-        error!(%path, "FileServer path is not a directory.");
-        warn!("Aborting early to prevent inevitable handler error.");
-        panic!("invalid directory: refusing to continue");
-    }
-    let path = path.to_path_buf();
-    move |f, _r| {
-        FileResponse::File(f.map_path(|p| path.join(p)))
-    }
-}
-
-/// Prepends the provided path, to serve a single static file.
-///
-/// # Example
-///
-/// ```rust,no_run
-/// # use rocket::fs::{FileServer, file_root};
-/// # fn make_server() -> FileServer {
-/// FileServer::empty()
-///     .map_file(file_root("static/index.html"))
-/// # }
-/// ```
-///
-/// # Panics
-///
-/// Panics if `path` does not exist. See [`file_root_permissive`] for a
-/// non-panicing variant.
-pub fn file_root(path: impl AsRef<Path>) -> impl FileMap {
-    let path = path.as_ref();
-    if !path.exists() {
-        let path = path.display();
-        error!(%path, "FileServer path does not exist.");
-        warn!("Aborting early to prevent inevitable handler error.");
-        panic!("invalid file: refusing to continue");
-    }
-    let path = path.to_path_buf();
-    move |f, _r| {
-        FileResponse::File(f.map_path(|p| path.join(p)))
-    }
-}
-
-/// Prepends the provided path, without checking to ensure the path exists during
-/// startup.
-///
-/// # Example
-///
-/// ```rust,no_run
-/// # use rocket::fs::{FileServer, file_root_permissive};
-/// # fn make_server() -> FileServer {
-/// FileServer::empty()
-///     .map_file(file_root_permissive("/tmp/rocket"))
-/// # }
-/// ```
-pub fn file_root_permissive(path: impl AsRef<Path>) -> impl FileMap {
-    let path = path.as_ref().to_path_buf();
-    move |f, _r| {
-        FileResponse::File(f.map_path(|p| path.join(p)))
-    }
-}
-
-/// Filters out any path that contains a file or directory name starting with a
-/// dot. If used after `dir_root`, this will also check the root path for dots, and
-/// filter them.
-///
-/// # Example
-///
-/// ```rust,no_run
-/// # use rocket::fs::{FileServer, filter_dotfiles, dir_root};
-/// # fn make_server() -> FileServer {
-/// FileServer::empty()
-///     .filter_file(filter_dotfiles)
-///     .map_file(dir_root("static"))
-/// # }
-/// ```
-pub fn filter_dotfiles(file: &File<'_, '_>, _req: &Request<'_>) -> bool {
-    !file.path.iter().any(|s| s.as_encoded_bytes().starts_with(b"."))
-}
-
-/// Normalize directory accesses to always include a trailing slash.
-///
-/// Should normally be used after `dir_root` (or another rewrite that adds
-/// a root), since it needs the full path to check whether a path points to
-/// a directory.
-///
-/// # Example
-///
-/// Appends a slash to any request for a directory without a trailing slash
-/// ```rust,no_run
-/// # use rocket::fs::{FileServer, normalize_dirs, dir_root};
-/// # fn make_server() -> FileServer {
-/// FileServer::empty()
-///     .map_file(dir_root("static"))
-///     .map_file(normalize_dirs)
-/// # }
-/// ```
-pub fn normalize_dirs<'p, 'h>(file: File<'p, 'h>, req: &Request<'_>) -> FileResponse<'p, 'h> {
-    if !req.uri().path().raw().ends_with('/') && file.path.is_dir() {
-        FileResponse::Redirect(Redirect::permanent(
-            // Known good path + '/' is a good path
-            req.uri().clone().into_owned().map_path(|p| format!("{p}/")).unwrap()
-        ))
-    } else {
-        FileResponse::File(file)
-    }
-}
-
-/// Appends a file name to all directory accesses.
-///
-/// Must be used after `dir_root`, since it needs the full path to check whether it is
-/// a directory.
-///
-/// # Example
-///
-/// Appends `index.html` to any directory access.
-/// ```rust,no_run
-/// # use rocket::fs::{FileServer, index, dir_root};
-/// # fn make_server() -> FileServer {
-/// FileServer::empty()
-///     .map_file(dir_root("static"))
-///     .map_file(index("index.html"))
-/// # }
-/// ```
-pub fn index(index: &'static str) -> impl FileMap {
-    move |f, _r| if f.path.is_dir() {
-        FileResponse::File(f.map_path(|p| p.join(index)))
-    } else {
-        FileResponse::File(f)
-    }
-}
-
 impl FileServer {
     /// The default rank use by `FileServer` routes.
     const DEFAULT_RANK: isize = 10;
 
-    /// Constructs a new `FileServer`, with default rank, and no
-    /// rewrites.
-    ///
-    /// See [`FileServer::empty_ranked()`].
-    pub fn empty() -> Self {
-        Self::empty_ranked(Self::DEFAULT_RANK)
-    }
-
-    /// Constructs a new `FileServer`, with specified rank, and no
-    /// rewrites.
-    ///
-    /// # Example
-    ///
-    /// Replicate the output of [`FileServer::new()`].
-    /// ```rust,no_run
-    /// # use rocket::fs::{FileServer, filter_dotfiles, dir_root, normalize_dirs};
-    /// # fn launch() -> FileServer {
-    /// FileServer::empty_ranked(10)
-    ///     .filter_file(filter_dotfiles)
-    ///     .map_file(dir_root("static"))
-    ///     .map_file(normalize_dirs)
-    /// # }
-    /// ```
-    pub fn empty_ranked(rank: isize) -> Self {
-        Self {
-            rewrites: vec![],
-            rank,
-        }
-    }
-
-    /// Constructs a new `FileServer`, with the defualt rank of 10.
-    ///
-    /// See [`FileServer::new`].
-    pub fn from<P: AsRef<Path>>(path: P) -> Self {
-        Self::new(path, Self::DEFAULT_RANK)
-    }
-
     /// Constructs a new `FileServer` that serves files from the file system
-    /// `path`, with the specified rank.
+    /// `path` with a default rank.
     ///
     /// Adds a set of default rewrites:
     /// - [`filter_dotfiles`]: Hides all dotfiles.
-    /// - [`dir_root(path)`](dir_root): Applies the root path.
+    /// - [`prefix(path)`](prefix): Applies the root path.
     /// - [`normalize_dirs`]: Normalizes directories to have a trailing slash.
     /// - [`index("index.html")`](index): Appends `index.html` to directory requests.
-    pub fn new<P: AsRef<Path>>(path: P, rank: isize) -> Self {
-        Self::empty_ranked(rank)
-            .filter_file(filter_dotfiles)
-            .map_file(dir_root(path))
-            .map_file(normalize_dirs)
-            .map_file(index("index.html"))
+    pub fn from<P: AsRef<Path>>(path: P) -> Self {
+        Self::empty()
+            .filter(filter_dotfiles)
+            .map(prefix(path))
+            .map(normalize_dirs)
+            .map(index("index.html"))
     }
 
-    /// Generic rewrite to transform one FileResponse to another.
+    /// Constructs a new `FileServer`, with default rank, and no rewrites.
+    ///
+    /// See [`FileServer::empty_ranked()`].
+    pub fn empty() -> Self {
+        Self {
+            rewrites: vec![],
+            rank: Self::DEFAULT_RANK
+        }
+    }
+
+    /// Sets the rank of the route emitted by the `FileServer` to `rank`.
+    ///
+    /// # Example
+    ///
+    /// ```rust,no_run
+    /// # use rocket::fs::FileServer;
+    /// # fn make_server() -> FileServer {
+    /// FileServer::empty()
+    ///    .rank(5)
+    ///  }
+    pub fn rank(mut self, rank: isize) -> Self {
+        self.rank = rank;
+        self
+    }
+
+    /// Generic rewrite to transform one Rewrite to another.
     ///
     /// # Example
     ///
     /// Redirects all requests that have been filtered to the root of the `FileServer`.
+    ///
     /// ```rust,no_run
-    /// # use rocket::{fs::{FileServer, FileResponse}, response::Redirect,
-    /// #     uri, Build, Rocket, Request};
-    /// fn redir_missing<'p, 'h>(p: Option<FileResponse<'p, 'h>>, _req: &Request<'_>)
-    ///     -> Option<FileResponse<'p, 'h>>
-    /// {
+    /// # use rocket::{Rocket, Build, Request};
+    /// # use rocket::fs::{FileServer, Rewrite};
+    /// # use rocket::{response::Redirect, #     uri, Build, Rocket, Request};
+    /// fn redir_missing<'r>(p: Option<Rewrite<'r>>, _req: &Request<'_>) -> Option<Rewrite<'r>> {
     ///     match p {
     ///         None => Redirect::temporary(uri!("/")).into(),
     ///         p => p,
@@ -511,13 +137,13 @@ impl FileServer {
     ///
     /// # fn launch() -> Rocket<Build> {
     /// rocket::build()
-    ///     .mount("/", FileServer::from("static").and_rewrite(redir_missing))
+    ///     .mount("/", FileServer::from("static").rewrite(redir_missing))
     /// # }
     /// ```
     ///
     /// Note that `redir_missing` is not a closure in this example. Making it a closure
     /// causes compilation to fail with a lifetime error. It really shouldn't but it does.
-    pub fn and_rewrite(mut self, f: impl Rewriter) -> Self {
+    pub fn rewrite(mut self, f: impl Rewriter) -> Self {
         self.rewrites.push(Arc::new(f));
         self
     }
@@ -528,20 +154,35 @@ impl FileServer {
     ///
     /// Filter out all paths with a filename of `hidden`.
     /// ```rust,no_run
-    /// # use rocket::{fs::FileServer, response::Redirect, uri, Rocket, Build};
-    /// # fn launch() -> Rocket<Build> {
-    /// rocket::build()
-    ///     .mount(
-    ///         "/",
-    ///         FileServer::from("static")
-    ///            .filter_file(|f, _r| f.path.file_name() != Some("hidden".as_ref()))
-    ///     )
+    /// #[macro_use] extern crate rocket;
+    /// use rocket::fs::FileServer;
+    ///
+    /// #[launch]
+    /// fn rocket() -> _ {
+    ///     let server = FileServer::from("static")
+    ///         .filter(|f, _| f.path.file_name() != Some("hidden".as_ref()));
+    ///
+    ///     rocket::build()
+    ///         .mount("/", server)
     /// # }
     /// ```
-    pub fn filter_file<F>(self, f: F) -> Self
-        where F: Fn(&File<'_, '_>, &Request<'_>) -> bool + Send + Sync + 'static
+    pub fn filter<F>(self, f: F) -> Self
+        where F: Fn(&File<'_>, &Request<'_>) -> bool + Send + Sync + 'static
     {
-        self.and_rewrite(FilterFile(f))
+        struct FilterFile<F>(F);
+
+        impl<F> Rewriter for FilterFile<F>
+            where F: Fn(&File<'_>, &Request<'_>) -> bool + Send + Sync + 'static
+        {
+            fn rewrite<'r>(&self, f: Option<Rewrite<'r>>, r: &Request<'_>) -> Option<Rewrite<'r>> {
+                match f {
+                    Some(Rewrite::File(file)) if !self.0(&file, r) => None,
+                    path => path,
+                }
+            }
+        }
+
+        self.rewrite(FilterFile(f))
     }
 
     /// Transform files
@@ -556,30 +197,37 @@ impl FileServer {
     ///     .mount(
     ///         "/",
     ///         FileServer::from("static")
-    ///             .map_file(|f, _r| f.map_path(|p| p.join("hidden")).into())
+    ///             .map(|f, _r| f.map_path(|p| p.join("hidden")).into())
     ///     )
     /// # }
     /// ```
-    pub fn map_file<F>(self, f: F) -> Self
-        where F: for<'r, 'h> Fn(File<'r, 'h>, &Request<'_>)
-            -> FileResponse<'r, 'h> + Send + Sync + 'static
+    pub fn map<F>(self, f: F) -> Self
+        where F: for<'r> Fn(File<'r>, &Request<'_>) -> Rewrite<'r> + Send + Sync + 'static
     {
-        self.and_rewrite(MapFile(f))
+        struct MapFile<F>(F);
+
+        impl<F> Rewriter for MapFile<F>
+            where F: for<'r> Fn(File<'r>, &Request<'_>) -> Rewrite<'r> + Send + Sync + 'static,
+        {
+            fn rewrite<'r>(&self, f: Option<Rewrite<'r>>, r: &Request<'_>) -> Option<Rewrite<'r>> {
+                match f {
+                    Some(Rewrite::File(file)) => Some(self.0(file, r)),
+                    path => path,
+                }
+            }
+        }
+
+        self.rewrite(MapFile(f))
     }
 }
 
 impl From<FileServer> for Vec<Route> {
     fn from(server: FileServer) -> Self {
-        // let source = figment::Source::File(server.root.clone());
         let mut route = Route::ranked(server.rank, Method::Get, "/<path..>", server);
-        // I'd like to provide a more descriptive name, but we can't get more
-        // information out of `dyn Rewriter`
         route.name = Some("FileServer".into());
         vec![route]
     }
 }
-
-
 
 #[crate::async_trait]
 impl Handler for FileServer {
@@ -587,23 +235,28 @@ impl Handler for FileServer {
         use crate::http::uri::fmt::Path as UriPath;
         let path: Option<PathBuf> = req.segments::<Segments<'_, UriPath>>(0..).ok()
             .and_then(|segments| segments.to_path_buf(true).ok());
-        let mut response = path.as_ref().map(|p| FileResponse::File(File {
-            path: Cow::Borrowed(p),
-            headers: HeaderMap::new(),
-        }));
 
+        let mut response = path.map(|p| Rewrite::File(File::new(p)));
         for rewrite in &self.rewrites {
             response = rewrite.rewrite(response, req);
         }
 
-        match response {
-            Some(FileResponse::File(file)) => file.respond_to(req, data).await,
-            Some(FileResponse::Redirect(r)) => {
-                r.respond_to(req)
-                    .or_forward((data, Status::InternalServerError))
-            },
-            None => Outcome::forward(data, Status::NotFound),
-        }
+        let (outcome, status) = match response {
+            Some(Rewrite::File(f)) => (f.open().await.respond_to(req), Status::NotFound),
+            Some(Rewrite::Redirect(r)) => (r.respond_to(req), Status::InternalServerError),
+            None => return Outcome::forward(data, Status::NotFound),
+        };
+
+        outcome.or_forward((data, status))
+    }
+}
+
+impl fmt::Debug for FileServer {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("FileServer")
+            .field("rewrites", &Formatter(|f| write!(f, "<{} rewrites>", self.rewrites.len())))
+            .field("rank", &self.rank)
+            .finish()
     }
 }
 

--- a/core/lib/src/fs/server.rs
+++ b/core/lib/src/fs/server.rs
@@ -268,12 +268,10 @@ impl<F> Rewriter for MapFile<F>
 pub fn dir_root(path: impl AsRef<Path>)
     -> impl for<'p, 'h> Fn(File<'p, 'h>, &Request<'_>) -> FileResponse<'p, 'h> + Send + Sync + 'static
 {
-    use yansi::Paint as _;
-
     let path = path.as_ref();
     if !path.is_dir() {
         let path = path.display();
-        error!("FileServer path '{}' is not a directory.", path.primary());
+        error!(%path, "FileServer path is not a directory.");
         warn!("Aborting early to prevent inevitable handler error.");
         panic!("invalid directory: refusing to continue");
     }
@@ -301,12 +299,10 @@ pub fn dir_root(path: impl AsRef<Path>)
 pub fn file_root(path: impl AsRef<Path>)
     -> impl for<'p, 'h> Fn(File<'p, 'h>, &Request<'_>) -> FileResponse<'p, 'h> + Send + Sync + 'static
 {
-    use yansi::Paint as _;
-
     let path = path.as_ref();
     if !path.exists() {
         let path = path.display();
-        error!("FileServer path '{}' is not a file.", path.primary());
+        error!(%path, "FileServer path does not exist.");
         warn!("Aborting early to prevent inevitable handler error.");
         panic!("invalid file: refusing to continue");
     }

--- a/core/lib/src/fs/server.rs
+++ b/core/lib/src/fs/server.rs
@@ -335,11 +335,20 @@ impl FileServer {
     ///
     /// # Example
     ///
-    /// ```rust,no_compile
-    /// # // TODO: turn this into a proper test
-    /// FileServer::new("static/", Options::None)
-    ///     .rewrite(NormalizeDirs)
-    ///     .rewrite(Index::default())
+    /// ```rust,no_run
+    /// # #[macro_use] extern crate rocket;
+    /// use rocket::fs::{FileServer, Options, NormalizeDirs, Index};
+    ///
+    /// #[launch]
+    /// fn rocket() -> _ {
+    ///     rocket::build()
+    ///         .mount("/static", FileServer::from("/www/public"))
+    ///         .mount("/pub",
+    ///             FileServer::new("/www/public", Options::None)
+    ///                 .rewrite(NormalizeDirs)
+    ///                 .rewrite(Index::default())
+    ///         )
+    /// }
     /// ```
     /// In this example, order actually does matter. [`NormalizeDirs`] will convert a path to a
     /// directory without a trailing slash into a redirect to the same path, but with the trailing

--- a/core/lib/src/fs/server.rs
+++ b/core/lib/src/fs/server.rs
@@ -1,14 +1,15 @@
 use core::fmt;
 use std::any::{type_name, Any, TypeId};
+use std::borrow::Cow;
+use std::os::unix::ffi::OsStrExt;
 use std::path::{PathBuf, Path};
 use std::sync::Arc;
 
-use crate::{Data, Request};
-use crate::http::{Method, Status, uri::{Segments, Reference}, ext::IntoOwned, HeaderMap};
+use crate::fs::NamedFile;
+use crate::{Data, Request, outcome::IntoOutcome};
+use crate::http::{Method, HeaderMap, Header, uri::{Segments, Reference}, Status};
 use crate::route::{Route, Handler, Outcome};
 use crate::response::{Redirect, Responder};
-use crate::outcome::IntoOutcome;
-use crate::fs::NamedFile;
 
 /// Custom handler for serving static files.
 ///
@@ -65,25 +66,22 @@ use crate::fs::NamedFile;
 /// ```
 #[derive(Clone)]
 pub struct FileServer {
-    root: PathBuf,
-    options: Options,
-    // TODO: I'd prefer box, but this just makes Clone easier.
-    rewrites: Vec<Arc<dyn Rewrite>>,
+    // root: PathBuf,
+    rewrites: Vec<Arc<dyn Rewriter>>,
     rank: isize,
 }
 
 impl fmt::Debug for FileServer {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("FileServer")
-            .field("root", &self.root)
-            .field("options", &self.options)
+            // .field("root", &self.root)
             .field("rewrites", &DebugListRewrite(&self.rewrites))
             .field("rank", &self.rank)
             .finish()
     }
 }
 
-struct DebugListRewrite<'a>(&'a Vec<Arc<dyn Rewrite>>);
+struct DebugListRewrite<'a>(&'a Vec<Arc<dyn Rewriter>>);
 
 impl fmt::Debug for DebugListRewrite<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -91,77 +89,180 @@ impl fmt::Debug for DebugListRewrite<'_> {
     }
 }
 
-pub trait Rewrite: Send + Sync + Any {
+pub trait Rewriter: Send + Sync + Any {
     /// Modify RewritablePath as needed.
-    fn rewrite(&self, req: &Request<'_>, path: FileServerResponse, root: &Path)
-        -> FileServerResponse;
-    /// Allow multiple of the same rewrite
-    fn allow_multiple(&self) -> bool { false }
+    fn rewrite<'a>(&self, path: Option<FileResponse<'a>>) -> Option<FileResponse<'a>>;
     /// provides type name for debug printing
     fn name(&self) -> &'static str { type_name::<Self>() }
 }
 
 #[derive(Debug)]
-pub enum HiddenReason {
-    DoesNotExist,
-    DotFile,
-    PermissionDenied,
-    Other,
+pub enum FileResponse<'a> {
+    /// Status: Ok
+    File(File<'a>),
+    /// Status: Redirect
+    Redirect(Redirect),
 }
 
 #[derive(Debug)]
-pub enum FileServerResponse {
-    /// Status: Ok
-    File {
-        path: PathBuf,
-        headers: HeaderMap<'static>,
-    },
-    /// Status: NotFound
-    NotFound { path: PathBuf, reason: HiddenReason },
-    /// Status: Redirect
-    PermanentRedirect { to: Reference<'static> },
-    /// Status: Redirect (TODO: should we allow this?)
-    TemporaryRedirect { to: Reference<'static> },
+pub struct File<'a> {
+    pub path: Cow<'a, Path>,
+    pub headers: HeaderMap<'a>,
 }
 
-/// Rewrites the path to allow paths that include a component beginning with a
-/// a `.`. This rewrite should be applied first, before any other rewrite.
-pub struct DotFiles;
-impl Rewrite for DotFiles {
-    fn rewrite(&self, _req: &Request<'_>, path: FileServerResponse, _root: &Path)
-        -> FileServerResponse
-    {
+impl<'a> File<'a> {
+    pub fn with_header<'h: 'a, H: Into<Header<'h>>>(mut self, header: H) -> Self {
+        self.headers.add(header);
+        self
+    }
+
+    pub fn with_path(self, path: impl Into<Cow<'a, Path>>) -> Self {
+        Self {
+            path: path.into(),
+            headers: self.headers,
+        }
+    }
+
+    pub fn modify_path(self, f: impl FnOnce(&mut PathBuf)) -> Self {
+        let mut path = self.path.into_owned();
+        f(&mut path);
+        Self {
+            path: path.into(),
+            headers: self.headers,
+        }
+    }
+}
+
+
+
+impl<F: Send + Sync + Any> Rewriter for F
+    where F: for<'r> Fn(Option<FileResponse<'r>>) -> Option<FileResponse<'r>>
+{
+    fn rewrite<'a>(&self, path: Option<FileResponse<'a>>) -> Option<FileResponse<'a>> {
+        self(path)
+    }
+
+    fn name(&self) -> &'static str {
+        "Custom Rewrite"
+    }
+}
+
+pub struct FilterFile<F>(F);
+impl<F: Fn(&File<'_>) -> bool + Send + Sync + Any> Rewriter for FilterFile<F> {
+    fn rewrite<'a>(&self, path: Option<FileResponse<'a>>) -> Option<FileResponse<'a>> {
         match path {
-            FileServerResponse::NotFound { path: name, reason: HiddenReason::DotFile } =>
-                FileServerResponse::File { path: name, headers: HeaderMap::new() },
+            Some(FileResponse::File(file)) if !self.0(&file) => None,
+            path => path,
+        }
+    }
+
+    fn name(&self) -> &'static str {
+        "Custom file filter"
+    }
+}
+
+pub struct FilterRedirect<F>(F, Reference<'static>);
+impl<F: Fn(&File<'_>) -> bool + Send + Sync + Any> Rewriter for FilterRedirect<F> {
+    fn rewrite<'a>(&self, path: Option<FileResponse<'a>>) -> Option<FileResponse<'a>> {
+        match path {
+            Some(FileResponse::File(file)) if !self.0(&file) =>
+                Some(FileResponse::Redirect(Redirect::permanent(self.1.clone()))),
+            path => path,
+        }
+    }
+
+    fn name(&self) -> &'static str {
+        "Custom file filter with redirect"
+    }
+}
+
+pub struct MapFile<F>(F);
+impl<F: for<'r> Fn(File<'r>) -> File<'r> + Send + Sync + Any> Rewriter for MapFile<F> {
+    fn rewrite<'a>(&self, path: Option<FileResponse<'a>>) -> Option<FileResponse<'a>> {
+        match path {
+            Some(FileResponse::File(file)) => Some(FileResponse::File(self.0(file))),
+            path => path,
+        }
+    }
+
+    fn name(&self) -> &'static str {
+        "Custom file map"
+    }
+}
+
+pub struct Root(PathBuf);
+impl Rewriter for Root {
+    fn rewrite<'a>(&self, path: Option<FileResponse<'a>>) -> Option<FileResponse<'a>> {
+        match path {
+            Some(FileResponse::File(file)) => Some(FileResponse::File(File {
+                path: self.0.join(file.path).into(),
+                headers: file.headers,
+            })),
             path => path,
         }
     }
 }
-// struct Missing; // This only applies on startup, so this needs to be an option
-// impl Rewrite for Missing {
-//     fn rewrite(&self, req: &Request<'_>, path: &mut RewritablePath<'_>) {
-//         todo!()
-//     }
-// }
+impl Rewriter for MapFile<Root> {
+    fn rewrite<'a>(&self, path: Option<FileResponse<'a>>) -> Option<FileResponse<'a>> {
+        self.0.rewrite(path)
+    }
+}
 
-/// Rewrites a path to a directory to return the content of an index file, `index.html`
-/// by defualt.
-///
-/// # Examples
-/// - Rewrites `/` to `/index.html`
-/// - Rewrites `/home/` to `/home/index.html`
-/// - Does not rewrite `/home/test.html`
-pub struct Index(pub &'static str);
-impl Rewrite for Index {
-    fn rewrite(&self, _req: &Request<'_>, path: FileServerResponse, _root: &Path)
-        -> FileServerResponse
-    {
+pub struct BlockDotfiles;
+impl Rewriter for BlockDotfiles {
+    fn rewrite<'a>(&self, path: Option<FileResponse<'a>>) -> Option<FileResponse<'a>> {
         match path {
-            FileServerResponse::File { path: name, headers } if name.is_dir() =>
-                FileServerResponse::File { path: name.join(self.0), headers },
+            Some(FileResponse::File(file)) if file.path.iter()
+                .any(|seg| seg.as_bytes().starts_with(b".")) => None,
             path => path,
         }
+    }
+}
+impl Rewriter for FilterFile<BlockDotfiles> {
+    fn rewrite<'a>(&self, path: Option<FileResponse<'a>>) -> Option<FileResponse<'a>> {
+        self.0.rewrite(path)
+    }
+}
+
+/// Normalize directory accesses to always include a trailing slash.
+///
+/// Must be used before `Root`, otherwise it will redirect to the full
+/// path, including the root directory.
+pub struct NormalizeDirs;
+impl Rewriter for NormalizeDirs {
+    fn rewrite<'a>(&self, path: Option<FileResponse<'a>>) -> Option<FileResponse<'a>> {
+        match path {
+            // This 
+            Some(FileResponse::File(file)) if
+                    !file.path.as_os_str().as_encoded_bytes().ends_with(b"/")
+                    && file.path.is_dir()
+                => Some(FileResponse::Redirect(
+                    Redirect::permanent(format!("{}/", file.path.display()))
+                )),
+            path => path,
+        }
+    }
+}
+impl Rewriter for MapFile<NormalizeDirs> {
+    fn rewrite<'a>(&self, path: Option<FileResponse<'a>>) -> Option<FileResponse<'a>> {
+        self.0.rewrite(path)
+    }
+}
+
+/// Appends a file name to all directory accesses. `index.html` by default
+pub struct Index(pub &'static str);
+impl Rewriter for Index {
+    fn rewrite<'a>(&self, path: Option<FileResponse<'a>>) -> Option<FileResponse<'a>> {
+        match path {
+            Some(FileResponse::File(file)) if file.path.is_dir()
+                => Some(FileResponse::File(file.modify_path(|p| p.push(self.0)))),
+            path => path,
+        }
+    }
+}
+impl Rewriter for MapFile<Index> {
+    fn rewrite<'a>(&self, path: Option<FileResponse<'a>>) -> Option<FileResponse<'a>> {
+        self.0.rewrite(path)
     }
 }
 impl Default for Index {
@@ -170,228 +271,98 @@ impl Default for Index {
     }
 }
 
-
-// Actually, curiously, this already just works as-is (the only thing that prevents
-// it is the startup check)
-pub struct IndexFile;
-impl Rewrite for IndexFile {
-    fn rewrite(&self, _req: &Request<'_>, path: FileServerResponse, _root: &Path)
-        -> FileServerResponse
-    {
-        match path {
-            path => path,
-        }
-    }
-}
-
-/// Rewrites a path to a directory without a trailing slash to a redirect to
-/// the same directory with a trailing slash. This rewrite needs to be applied
-/// before [`Index`] and any other rewrite that changes the path to a file.
-///
-/// # Examples
-/// - Redirects `/home/test` to `/home/test/`
-/// - Does not redirect `/home/`
-/// - Does not redirect `/home/index.html`
-pub struct NormalizeDirs;
-impl Rewrite for NormalizeDirs {
-    fn rewrite(&self, req: &Request<'_>, path: FileServerResponse, _root: &Path)
-        -> FileServerResponse
-    {
-        match path {
-            FileServerResponse::File { path: name, .. } if !req.uri().path().ends_with('/') &&
-                name.is_dir() =>
-                FileServerResponse::PermanentRedirect {
-                    to: req.uri().map_path(|p| format!("{}/", p))
-                        .expect("adding a trailing slash to a known good path => valid path")
-                        .into_owned().into()
-                },
-            path => path,
-        }
-    }
-}
-
 impl FileServer {
     /// The default rank use by `FileServer` routes.
     const DEFAULT_RANK: isize = 10;
 
-    /// Constructs a new `FileServer` that serves files from the file system
-    /// `path`. By default, [`Options::Index`] is set, and the generated routes
-    /// have a rank of `10`. To serve static files with other options, use
-    /// [`FileServer::new()`]. To choose a different rank for generated routes,
-    /// use [`FileServer::rank()`].
+    /// Constructs a new `FileServer`, with default rank, and no
+    /// rewrites.
+    pub fn empty() -> Self {
+        Self {
+            rewrites: vec![],
+            rank: Self::DEFAULT_RANK,
+        }
+    }
+
+    /// Constructs a new `FileServer`, with the defualt rank of 10.
     ///
-    /// # Panics
-    ///
-    /// Panics if `path` does not exist or is not a directory.
-    ///
-    /// # Example
-    ///
-    /// Serve the static files in the `/www/public` local directory on path
-    /// `/static`.
-    ///
-    /// ```rust,no_run
-    /// # #[macro_use] extern crate rocket;
-    /// use rocket::fs::FileServer;
-    ///
-    /// #[launch]
-    /// fn rocket() -> _ {
-    ///     rocket::build().mount("/static", FileServer::from("/www/public"))
-    /// }
-    /// ```
-    ///
-    /// Exactly as before, but set the rank for generated routes to `30`.
-    ///
-    /// ```rust,no_run
-    /// # #[macro_use] extern crate rocket;
-    /// use rocket::fs::FileServer;
-    ///
-    /// #[launch]
-    /// fn rocket() -> _ {
-    ///     rocket::build().mount("/static", FileServer::from("/www/public").rank(30))
-    /// }
-    /// ```
-    #[track_caller]
+    /// See: [`FileServer::new`] for more details
     pub fn from<P: AsRef<Path>>(path: P) -> Self {
-        FileServer::new(path, Options::None)
-            .rewrite(NormalizeDirs)
-            .rewrite(Index("index.html"))
+        Self::new(path, Self::DEFAULT_RANK)
     }
 
     /// Constructs a new `FileServer` that serves files from the file system
-    /// `path` with `options` enabled. By default, the handler's routes have a
-    /// rank of `10`. To choose a different rank, use [`FileServer::rank()`].
-    ///
-    /// # Panics
-    ///
-    /// If [`Options::Missing`] is not set, panics if `path` does not exist or
-    /// is not a directory. Otherwise does not panic.
-    ///
-    /// # Example
-    ///
-    /// Serve the static files in the `/www/public` local directory on path
-    /// `/static` without serving index files or dot files. Additionally, serve
-    /// the same files on `/pub` with a route rank of -1 while also serving
-    /// index files and dot files.
-    ///
-    /// ```rust,no_run
-    /// # #[macro_use] extern crate rocket;
-    /// use rocket::fs::{FileServer, Options};
-    ///
-    /// #[launch]
-    /// fn rocket() -> _ {
-    ///     let options = Options::Index | Options::DotFiles;
-    ///     rocket::build()
-    ///         .mount("/static", FileServer::from("/www/public"))
-    ///         .mount("/pub", FileServer::new("/www/public", options).rank(-1))
-    /// }
-    /// ```
-    #[track_caller]
-    pub fn new<P: AsRef<Path>>(path: P, options: Options) -> Self {
+    /// `path`, with the specified rank.
+    /// 
+    /// Adds a set of default rewrites:
+    /// - [`BlockDotfiles`]: Hides all dotfiles
+    /// - [`NormalizeDirs`]: Normalizes directories to have a trailing slash
+    /// - [`Root(path)`](Root): Applies the root path
+    pub fn new<P: AsRef<Path>>(path: P, rank: isize) -> Self {
+        use crate::yansi::Paint;
+
         let path = path.as_ref();
-        if !options.contains(Options::Missing) {
-            #[allow(deprecated)]
-            if !options.contains(Options::IndexFile) && !path.is_dir() {
-                error!(path = %path.display(),
-                    "FileServer path does not point to a directory.\n\
-                    Aborting early to prevent inevitable handler runtime errors.");
-
-                panic!("invalid directory path: refusing to continue");
-            } else if !path.exists() {
-                error!(path = %path.display(),
-                    "FileServer path does not point to a file.\n\
-                    Aborting early to prevent inevitable handler runtime errors.");
-
-                panic!("invalid file path: refusing to continue");
-            }
+        if !path.exists() {
+            let path = path.display();
+            error!("FileServer path '{}' does not exist", path.primary());
+            // warn_!("Aborting early to prevent inevitable handler error.");
         }
-        let mut rewrites: Vec<Arc<dyn Rewrite>> = vec![];
-        #[allow(deprecated)]
-        if options.contains(Options::DotFiles) {
-            rewrites.push(Arc::new(DotFiles));
-        }
-        #[allow(deprecated)]
-        if options.contains(Options::NormalizeDirs) {
-            rewrites.push(Arc::new(NormalizeDirs));
-        }
-        #[allow(deprecated)]
-        if options.contains(Options::Index) {
-            rewrites.push(Arc::new(Index("index.html")));
-        }
-
-        FileServer { root: path.into(), options, rewrites, rank: Self::DEFAULT_RANK }
+        FileServer { rewrites: vec![
+            Arc::new(BlockDotfiles),
+            Arc::new(NormalizeDirs),
+            Arc::new(Root(path.into()))
+        ], rank }
     }
 
-    /// Removes all rewrites of a specific type.
-    ///
-    /// Ideally, this shouldn't exist, and it should be possible to always just not add
-    /// the rewrites you don't want.
-    pub fn remove_rewrites<T: Rewrite>(mut self) -> Self {
-        self.rewrites.retain(|r| r.as_ref().type_id() != TypeId::of::<T>());
+    /// Removes all rewrites of a specific type. This is primarily useful for removing
+    /// rewrites added by default, such as `BlockDotfiles`, `NormalizeDirs`, and `Root`
+    pub fn remove_rewrites<R: Rewriter + Any>(mut self) -> Self {
+        self.rewrites.retain(|r| { 
+            <_ as AsRef<dyn Rewriter>>::as_ref(&r).type_id() != TypeId::of::<R>()
+        });
         self
     }
 
-    /// Add a rewrite step to this `FileServer`. The order in which rewrites are added can make
-    /// a difference, since they are applied in the order they appear.
-    ///
-    /// # Example
-    ///
-    /// ```rust,no_run
-    /// # #[macro_use] extern crate rocket;
-    /// use rocket::fs::{FileServer, Options, NormalizeDirs, Index};
-    ///
-    /// #[launch]
-    /// fn rocket() -> _ {
-    ///     rocket::build()
-    ///         .mount("/static", FileServer::from("/www/public"))
-    ///         .mount("/pub",
-    ///             FileServer::new("/www/public", Options::None)
-    ///                 .rewrite(NormalizeDirs)
-    ///                 .rewrite(Index::default())
-    ///         )
-    /// }
-    /// ```
-    /// In this example, order actually does matter. [`NormalizeDirs`] will convert a path to a
-    /// directory without a trailing slash into a redirect to the same path, but with the trailing
-    /// slash. However, if the [`Index`] rewrite is applied first, the path will have been changed
-    /// to the `index.html` file, causing [`NormalizeDirs`] to do nothing.
-    pub fn rewrite(mut self, rewrite: impl Rewrite) -> Self {
-        if rewrite.allow_multiple() ||
-            !self.rewrites.iter().any(|f| f.as_ref().type_id() == rewrite.type_id()) {
-            self.rewrites.push(Arc::new(rewrite));
-        } else {
-            error!(
-                "Attempted to insert multiple of the same rewrite `{}` on a FileServer.\n\
-                Adding a rewrite that doesn't support duplicate rewrites is ignored",
-                rewrite.name()
-            );
-        }
+    /// Generic rewrite to transform one FileResponse to another
+    pub fn and_rewrite(mut self, f: impl Rewriter + 'static) -> Self {
+        self.rewrites.push(Arc::new(f));
         self
     }
 
-    /// Sets the rank for generated routes to `rank`.
-    ///
-    /// # Example
-    ///
-    /// ```rust,no_run
-    /// use rocket::fs::{FileServer, Options};
-    ///
-    /// // A `FileServer` created with `from()` with routes of rank `3`.
-    /// FileServer::from("/public").rank(3);
-    ///
-    /// // A `FileServer` created with `new()` with routes of rank `-15`.
-    /// FileServer::new("/public", Options::Index).rank(-15);
-    /// ```
-    pub fn rank(mut self, rank: isize) -> Self {
-        self.rank = rank;
-        self
+    /// Configure this `FileServer` instance to allow serving dotfiles.
+    pub fn allow_dotfiles(self) -> Self {
+        self.remove_rewrites::<BlockDotfiles>()
+    }
+
+    /// Filter what files this `FileServer` will respond with
+    pub fn filter_file<F>(self, f: F) -> Self
+        // where F: Fn(&File<'_>) -> bool + Send + Sync + Any
+        where FilterFile<F>: Rewriter
+    {
+        self.and_rewrite(FilterFile(f))
+    }
+
+    /// Filter what files this `FileServer` will respond with
+    pub fn filter_file_or_redirect<F>(self, f: F, to: Reference<'static>) -> Self
+        where F: Fn(&File<'_>) -> bool + Send + Sync + Any
+    {
+        self.and_rewrite(FilterRedirect(f, to))
+    }
+
+    /// Transform files before responding
+    pub fn map_file<F>(self, f: F) -> Self
+        // where F: for<'r> Fn(File<'r>) -> File<'r> + Send + Sync + Any
+        where MapFile<F>: Rewriter
+    {
+        self.and_rewrite(MapFile(f))
     }
 }
 
 impl From<FileServer> for Vec<Route> {
     fn from(server: FileServer) -> Self {
-        let source = figment::Source::File(server.root.clone());
+        // let source = figment::Source::File(server.root.clone());
         let mut route = Route::ranked(server.rank, Method::Get, "/<path..>", server);
-        route.name = Some(format!("FileServer: {}", source).into());
+        route.name = Some(format!("FileServer").into());
         vec![route]
     }
 }
@@ -400,35 +371,15 @@ impl From<FileServer> for Vec<Route> {
 impl Handler for FileServer {
     async fn handle<'r>(&self, req: &'r Request<'_>, data: Data<'r>) -> Outcome<'r> {
         use crate::http::uri::fmt::Path as UriPath;
-        let path = req.segments::<Segments<'_, UriPath>>(0..).ok()
-            .and_then(|segments| segments.to_path_buf_dotfiles().ok())
-            .map(|(path, dots)| (self.root.join(path), dots));
-        let mut response = match path {
-            Some((path, false)) =>
-                FileServerResponse::File { path, headers: HeaderMap::new() },
-            Some((path, true)) =>
-                FileServerResponse::NotFound { path, reason: HiddenReason::DotFile },
-            None => return Outcome::forward(data, Status::NotFound),
-        };
-        // println!("initial: {response:?}");
+        let mut response = req.segments::<Segments<'_, UriPath>>(0..).ok()
+            .and_then(|segments| segments.to_path_buf(true).ok())
+            .map(|path| FileResponse::File(File { path: path.into(), headers: HeaderMap::new() }));
+
         for rewrite in &self.rewrites {
-            response = rewrite.rewrite(req, response, &self.root);
-            // println!("after: {} {response:?}", rewrite.name());
+            response = rewrite.rewrite(response);
         }
-        // Open TODOs:
-        // - Should we validate the location of the path? We've aleady removed any
-        //   `..` and other traversal mechanisms, before passing to the rewrites.
-        // - Should we allow more control? I think we should require the payload
-        //   to be a file on the disk, and the only thing left to control would be
-        //   headers (which we allow configuring), and status, which we allow a specific
-        //   set.
-        // - Should we prepend the path root? I think we should, since I don't think the
-        //   relative path is particularly useful.
         match response {
-            FileServerResponse::File { path, headers } => {
-                if path.is_dir() {
-                    return Outcome::Forward((data, Status::NotFound));
-                }
+            Some(FileResponse::File(File { path, headers })) => {
                 NamedFile::open(path).await.respond_to(req).map(|mut r| {
                     for header in headers {
                         r.adjoin_raw_header(header.name.as_str().to_owned(), header.value);
@@ -436,180 +387,11 @@ impl Handler for FileServer {
                     r
                 }).or_forward((data, Status::NotFound))
             },
-            FileServerResponse::NotFound { .. } => Outcome::forward(data, Status::NotFound),
-            FileServerResponse::PermanentRedirect { to } => Redirect::permanent(to)
-                .respond_to(req)
-                .or_forward((data, Status::InternalServerError)),
-            FileServerResponse::TemporaryRedirect { to } => Redirect::temporary(to)
-                .respond_to(req)
-                .or_forward((data, Status::InternalServerError)),
+            Some(FileResponse::Redirect(r)) => {
+                r.respond_to(req).or_forward((data, Status::InternalServerError))
+            },
+            None => Outcome::forward(data, Status::NotFound),
         }
-    }
-}
-
-/// A bitset representing configurable options for [`FileServer`].
-///
-/// The valid options are:
-///
-///   * [`Options::None`] - Return only present, visible files.
-///   * [`Options::DotFiles`] - In addition to visible files, return dotfiles.
-///   * [`Options::Index`] - Render `index.html` pages for directory requests.
-///   * [`Options::IndexFile`] - Allow serving a single file as the index.
-///   * [`Options::Missing`] - Don't fail if the path to serve is missing.
-///   * [`Options::NormalizeDirs`] - Redirect directories without a trailing
-///     slash to ones with a trailing slash.
-///
-/// `Options` structures can be `or`d together to select two or more options.
-/// For instance, to request that both dot files and index pages be returned,
-/// use `Options::DotFiles | Options::Index`.
-#[derive(Debug, Clone, Copy)]
-pub struct Options(u8);
-
-#[allow(non_upper_case_globals, non_snake_case)]
-impl Options {
-    /// All options disabled.
-    ///
-    /// Note that this is different than [`Options::default()`](#impl-Default),
-    /// which enables options.
-    pub const None: Options = Options(0);
-
-    /// Respond to requests for a directory with the `index.html` file in that
-    /// directory, if it exists.
-    ///
-    /// When enabled, [`FileServer`] will respond to requests for a directory
-    /// `/foo` or `/foo/` with the file at `${root}/foo/index.html` if it
-    /// exists. When disabled, requests to directories will always forward.
-    ///
-    /// **Enabled by default.**
-    #[deprecated(note = "Replaced by `.rewrite(Index(\"index.html\"))`")]
-    pub const Index: Options = Options(1 << 0);
-
-    /// Allow serving dotfiles.
-    ///
-    /// When enabled, [`FileServer`] will respond to requests for files or
-    /// directories beginning with `.`. When disabled, any dotfiles will be
-    /// treated as missing.
-    ///
-    /// **Disabled by default.**
-    #[deprecated(note = "Replaced by `.rewrite(DotFiles)`")]
-    pub const DotFiles: Options = Options(1 << 1);
-
-    /// Normalizes directory requests by redirecting requests to directory paths
-    /// without a trailing slash to ones with a trailing slash.
-    ///
-    /// **Enabled by default.**
-    ///
-    /// When enabled, the [`FileServer`] handler will respond to requests for a
-    /// directory without a trailing `/` with a permanent redirect (308) to the
-    /// same path with a trailing `/`. This ensures relative URLs within any
-    /// document served from that directory will be interpreted relative to that
-    /// directory rather than its parent.
-    ///
-    /// # Example
-    ///
-    /// Given the following directory structure...
-    ///
-    /// ```text
-    /// static/
-    /// └── foo/
-    ///     ├── cat.jpeg
-    ///     └── index.html
-    /// ```
-    ///
-    /// And the following server:
-    ///
-    /// ```text
-    /// rocket.mount("/", FileServer::from("static"))
-    /// ```
-    ///
-    /// ...requests to `example.com/foo` will be redirected to
-    /// `example.com/foo/`. If `index.html` references `cat.jpeg` as a relative
-    /// URL, the browser will resolve the URL to `example.com/foo/cat.jpeg`,
-    /// which in-turn Rocket will match to `/static/foo/cat.jpg`.
-    ///
-    /// Without this option, requests to `example.com/foo` would not be
-    /// redirected. `index.html` would be rendered, and the relative link to
-    /// `cat.jpeg` would be resolved by the browser as `example.com/cat.jpeg`.
-    /// Rocket would thus try to find `/static/cat.jpeg`, which does not exist.
-    #[deprecated(note = "Replaced by `.rewrite(NormalizeDirs)`")]
-    pub const NormalizeDirs: Options = Options(1 << 2);
-
-    /// Allow serving a file instead of a directory.
-    ///
-    /// By default, `FileServer` will error on construction if the path to serve
-    /// does not point to a directory. When this option is enabled, if a path to
-    /// a file is provided, `FileServer` will serve the file as the root of the
-    /// mount path.
-    ///
-    /// # Example
-    ///
-    /// If the file tree looks like:
-    ///
-    /// ```text
-    /// static/
-    /// └── cat.jpeg
-    /// ```
-    ///
-    /// Then `cat.jpeg` can be served at `/cat` with:
-    ///
-    /// ```rust,no_run
-    /// # #[macro_use] extern crate rocket;
-    /// use rocket::fs::{FileServer, Options};
-    ///
-    /// #[launch]
-    /// fn rocket() -> _ {
-    ///     rocket::build()
-    ///         .mount("/cat", FileServer::new("static/cat.jpeg", Options::IndexFile))
-    /// }
-    /// ```
-    pub const IndexFile: Options = Options(1 << 3);
-
-    /// Don't fail if the file or directory to serve is missing.
-    ///
-    /// By default, `FileServer` will error if the path to serve is missing to
-    /// prevent inevitable 404 errors. This option overrides that.
-    pub const Missing: Options = Options(1 << 4);
-
-    /// Returns `true` if `self` is a superset of `other`. In other words,
-    /// returns `true` if all of the options in `other` are also in `self`.
-    ///
-    /// # Example
-    ///
-    /// ```rust
-    /// use rocket::fs::Options;
-    ///
-    /// let index_request = Options::Index | Options::DotFiles;
-    /// assert!(index_request.contains(Options::Index));
-    /// assert!(index_request.contains(Options::DotFiles));
-    ///
-    /// let index_only = Options::Index;
-    /// assert!(index_only.contains(Options::Index));
-    /// assert!(!index_only.contains(Options::DotFiles));
-    ///
-    /// let dot_only = Options::DotFiles;
-    /// assert!(dot_only.contains(Options::DotFiles));
-    /// assert!(!dot_only.contains(Options::Index));
-    /// ```
-    #[inline]
-    pub fn contains(self, other: Options) -> bool {
-        (other.0 & self.0) == other.0
-    }
-}
-
-/// The default set of options: `Options::Index | Options:NormalizeDirs`.
-impl Default for Options {
-    #[allow(deprecated)]
-    fn default() -> Self {
-        Options::Index | Options::NormalizeDirs
-    }
-}
-
-impl std::ops::BitOr for Options {
-    type Output = Self;
-
-    #[inline(always)]
-    fn bitor(self, rhs: Self) -> Self {
-        Options(self.0 | rhs.0)
     }
 }
 

--- a/core/lib/src/response/redirect.rs
+++ b/core/lib/src/response/redirect.rs
@@ -144,6 +144,12 @@ impl Redirect {
    pub fn moved<U: TryInto<Reference<'static>>>(uri: U) -> Redirect {
        Redirect(Status::MovedPermanently, uri.try_into().ok())
    }
+
+    pub fn map_uri<U: TryInto<Reference<'static>>>(self, f: impl FnOnce(Reference<'static>) -> U)
+        -> Redirect
+    {
+        Redirect(self.0, self.1.and_then(|p| f(p).try_into().ok()))
+    }
 }
 
 /// Constructs a response with the appropriate status code and the given URL in

--- a/core/lib/src/response/redirect.rs
+++ b/core/lib/src/response/redirect.rs
@@ -45,7 +45,7 @@ use crate::http::Status;
 ///
 /// [`Origin`]: crate::http::uri::Origin
 /// [`uri!`]: ../macro.uri.html
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Redirect(Status, Option<Reference<'static>>);
 
 impl Redirect {

--- a/core/lib/src/response/response.rs
+++ b/core/lib/src/response/response.rs
@@ -637,6 +637,10 @@ impl<'r> Response<'r> {
         &self.headers
     }
 
+    pub fn set_header_map<'h: 'r>(&mut self, headers: HeaderMap<'h>) {
+        self.headers = headers;
+    }
+
     /// Sets the header `header` in `self`. Any existing headers with the name
     /// `header.name` will be lost, and only `header` will remain. The type of
     /// `header` can be any type that implements `Into<Header>`. See [trait

--- a/core/lib/tests/file_server.rs
+++ b/core/lib/tests/file_server.rs
@@ -14,7 +14,7 @@ fn rocket() -> Rocket<Build> {
     let root = static_root();
     rocket::build()
         .mount("/default", FileServer::from(&root))
-        .mount("/no_index", FileServer::new(&root, Options::None))
+        .mount("/no_index", dbg!(FileServer::new(&root, Options::None)))
         .mount("/dots", FileServer::new(&root, Options::DotFiles))
         .mount("/index", FileServer::new(&root, Options::Index))
         .mount("/both", FileServer::new(&root, Options::DotFiles | Options::Index))

--- a/core/lib/tests/file_server.rs
+++ b/core/lib/tests/file_server.rs
@@ -16,25 +16,25 @@ fn rocket() -> Rocket<Build> {
         .mount("/default", FileServer::new(&root))
         .mount(
             "/no_index",
-            FileServer::empty()
+            FileServer::identity()
                 .filter(|f, _| f.is_visible())
                 .rewrite(Prefix::checked(&root))
         )
         .mount(
             "/dots",
-            FileServer::empty()
+            FileServer::identity()
                 .rewrite(Prefix::checked(&root))
         )
         .mount(
             "/index",
-            FileServer::empty()
+            FileServer::identity()
                 .filter(|f, _| f.is_visible())
                 .rewrite(Prefix::checked(&root))
                 .rewrite(DirIndex::unconditional("index.html"))
         )
         .mount(
             "/try_index",
-            FileServer::empty()
+            FileServer::identity()
                 .filter(|f, _| f.is_visible())
                 .rewrite(Prefix::checked(&root))
                 .rewrite(DirIndex::if_exists("index.html"))
@@ -42,20 +42,20 @@ fn rocket() -> Rocket<Build> {
         )
         .mount(
             "/both",
-            FileServer::empty()
+            FileServer::identity()
                 .rewrite(Prefix::checked(&root))
                 .rewrite(DirIndex::unconditional("index.html"))
         )
         .mount(
             "/redir",
-            FileServer::empty()
+            FileServer::identity()
                 .filter(|f, _| f.is_visible())
                 .rewrite(Prefix::checked(&root))
                 .rewrite(TrailingDirs)
         )
         .mount(
             "/redir_index",
-            FileServer::empty()
+            FileServer::identity()
                 .filter(|f, _| f.is_visible())
                 .rewrite(Prefix::checked(&root))
                 .rewrite(TrailingDirs)
@@ -63,13 +63,13 @@ fn rocket() -> Rocket<Build> {
         )
         .mount(
             "/index_file",
-            FileServer::empty()
+            FileServer::identity()
                 .filter(|f, _| f.is_visible())
                 .rewrite(File::checked(root.join("other/hello.txt")))
         )
         .mount(
             "/missing_root",
-            FileServer::empty()
+            FileServer::identity()
                 .filter(|f, _| f.is_visible())
                 .rewrite(File::new(root.join("no_file")))
         )

--- a/core/lib/tests/file_server.rs
+++ b/core/lib/tests/file_server.rs
@@ -5,7 +5,14 @@ use rocket::{Rocket, Route, Build};
 use rocket::http::Status;
 use rocket::local::blocking::Client;
 use rocket::fs::{
-    dir_root, file_root, filter_dotfiles, index, file_root_permissive, normalize_dirs, relative, FileServer
+    dir_root,
+    file_root,
+    filter_dotfiles,
+    index,
+    file_root_permissive,
+    normalize_dirs,
+    relative,
+    FileServer
 };
 
 fn static_root() -> &'static Path {
@@ -60,14 +67,12 @@ fn rocket() -> Rocket<Build> {
             FileServer::empty()
                 .filter_file(filter_dotfiles)
                 .map_file(file_root(root.join("other/hello.txt")))
-            
         )
         .mount(
             "/missing_root",
             FileServer::empty()
                 .filter_file(filter_dotfiles)
                 .map_file(file_root_permissive(root.join("no_file")))
-            
         )
 }
 

--- a/core/lib/tests/file_server.rs
+++ b/core/lib/tests/file_server.rs
@@ -4,7 +4,7 @@ use std::path::Path;
 use rocket::{Rocket, Route, Build};
 use rocket::http::Status;
 use rocket::local::blocking::Client;
-use rocket::fs::{FileServer, Options, relative};
+use rocket::fs::{relative, DotFiles, FileServer, Index, NormalizeDirs, Options};
 
 fn static_root() -> &'static Path {
     Path::new(relative!("/tests/static"))
@@ -15,11 +15,21 @@ fn rocket() -> Rocket<Build> {
     rocket::build()
         .mount("/default", FileServer::from(&root))
         .mount("/no_index", dbg!(FileServer::new(&root, Options::None)))
-        .mount("/dots", FileServer::new(&root, Options::DotFiles))
-        .mount("/index", FileServer::new(&root, Options::Index))
-        .mount("/both", FileServer::new(&root, Options::DotFiles | Options::Index))
-        .mount("/redir", FileServer::new(&root, Options::NormalizeDirs))
-        .mount("/redir_index", FileServer::new(&root, Options::NormalizeDirs | Options::Index))
+        .mount("/dots", FileServer::new(&root, Options::None).rewrite(DotFiles))
+        .mount("/index", FileServer::new(&root, Options::None).rewrite(Index("index.html")))
+        .mount(
+            "/both",
+            FileServer::new(&root, Options::None)
+                .rewrite(DotFiles)
+                .rewrite(Index("index.html"))
+        )
+        .mount("/redir", FileServer::new(&root, Options::None).rewrite(NormalizeDirs))
+        .mount(
+            "/redir_index",
+            FileServer::new(&root, Options::None)
+                .rewrite(NormalizeDirs)
+                .rewrite(Index("index.html"))
+        )
 }
 
 static REGULAR_FILES: &[&str] = &[

--- a/core/lib/tests/file_server.rs
+++ b/core/lib/tests/file_server.rs
@@ -5,7 +5,7 @@ use rocket::{Rocket, Route, Build};
 use rocket::http::Status;
 use rocket::local::blocking::Client;
 use rocket::fs::{
-    dir_root, file_root, filter_dotfiles, index, missing_root, normalize_dirs, relative, FileServer
+    dir_root, file_root, filter_dotfiles, index, file_root_permissive, normalize_dirs, relative, FileServer
 };
 
 fn static_root() -> &'static Path {
@@ -66,7 +66,7 @@ fn rocket() -> Rocket<Build> {
             "/missing_root",
             FileServer::empty()
                 .filter_file(filter_dotfiles)
-                .map_file(missing_root(root.join("no_file")))
+                .map_file(file_root_permissive(root.join("no_file")))
             
         )
 }

--- a/core/lib/tests/static/inner/index.html
+++ b/core/lib/tests/static/inner/index.html
@@ -1,1 +1,1 @@
-Inner index.
+Inner index.html

--- a/core/lib/tests/static/other/index.htm
+++ b/core/lib/tests/static/other/index.htm
@@ -1,0 +1,1 @@
+Inner index.htm

--- a/docs/guide/05-requests.md
+++ b/docs/guide/05-requests.md
@@ -169,7 +169,7 @@ async fn files(file: PathBuf) -> Option<NamedFile> {
   fn rocket() -> _ {
       rocket::build()
            // serve files from `/www/static` at path `/public`
-          .mount("/public", FileServer::from("/www/static"))
+          .mount("/public", FileServer::new("/www/static"))
   }
   ```
 

--- a/docs/guide/11-deploying.md
+++ b/docs/guide/11-deploying.md
@@ -49,7 +49,7 @@ For any deployment, it's important to keep in mind:
      #[launch]
      fn rocket() -> _ {
          rocket::build()
-             .mount("/", FileServer::from("./static"))
+             .mount("/", FileServer::new("./static"))
              .attach(Template::fairing())
      }
      ```

--- a/examples/chat/src/main.rs
+++ b/examples/chat/src/main.rs
@@ -54,5 +54,5 @@ fn rocket() -> _ {
     rocket::build()
         .manage(channel::<Message>(1024).0)
         .mount("/", routes![post, events])
-        .mount("/", FileServer::from(relative!("static")))
+        .mount("/", FileServer::new(relative!("static")))
 }

--- a/examples/forms/src/main.rs
+++ b/examples/forms/src/main.rs
@@ -93,5 +93,5 @@ fn rocket() -> _ {
     rocket::build()
         .mount("/", routes![index, submit])
         .attach(Template::fairing())
-        .mount("/", FileServer::from(relative!("/static")))
+        .mount("/", FileServer::new(relative!("/static")))
 }

--- a/examples/static-files/src/main.rs
+++ b/examples/static-files/src/main.rs
@@ -23,5 +23,5 @@ mod manual {
 fn rocket() -> _ {
     rocket::build()
         .mount("/", rocket::routes![manual::second])
-        .mount("/", FileServer::from(relative!("static")))
+        .mount("/", FileServer::new(relative!("static")))
 }

--- a/examples/static-files/src/tests.rs
+++ b/examples/static-files/src/tests.rs
@@ -63,7 +63,7 @@ fn test_icon_file() {
 
 #[test]
 fn test_invalid_path() {
-    test_query_file("/hidden", None, Status::PermanentRedirect);
+    test_query_file("/hidden", None, Status::TemporaryRedirect);
     test_query_file("/thou_shalt_not_exist", None, Status::NotFound);
     test_query_file("/thou/shalt/not/exist", None, Status::NotFound);
     test_query_file("/thou/shalt/not/exist?a=b&c=d", None, Status::NotFound);

--- a/examples/todo/src/main.rs
+++ b/examples/todo/src/main.rs
@@ -110,7 +110,7 @@ fn rocket() -> _ {
         .attach(DbConn::fairing())
         .attach(Template::fairing())
         .attach(AdHoc::on_ignite("Run Migrations", run_migrations))
-        .mount("/", FileServer::from(relative!("static")))
+        .mount("/", FileServer::new(relative!("static")))
         .mount("/", routes![index])
         .mount("/todo", routes![new, toggle, delete])
 }

--- a/examples/upgrade/src/main.rs
+++ b/examples/upgrade/src/main.rs
@@ -39,5 +39,5 @@ fn echo_raw(ws: ws::WebSocket) -> ws::Stream!['static] {
 fn rocket() -> _ {
     rocket::build()
         .mount("/", routes![echo_channel, echo_stream, echo_raw])
-        .mount("/", FileServer::from(fs::relative!("static")))
+        .mount("/", FileServer::new(fs::relative!("static")))
 }


### PR DESCRIPTION
The goal of this PR is to implement a Rewrite API, following the basic outline presented in #2716.

The goal is to replace the existing `Options` on `FileServer` to instead use a rewrite based API. This will make `FileServer` pluggable, making it possible to implement things like cached compression implementable outside of Rocket.

The basic usage example is as follows:
```rust
FileServer::new("static")
   .rewrite(DotFiles)
   .rewrite(NormalizeDirs)
   .rewrite(Index("index.html"))
```

There are a couple of major limitations to the rewrite trait, specifically the file to be served must exist on the local file system, and the trait is synchronous, so it should not do any IO when rewriting paths. However, I would argue that if you want to move beyond these, you should just implement your own `Handler`, and fully replace `FileServer`.