### PR TITLE
Make uniqueify_with generate deterministic macro names, to fix build failures

### DIFF
--- a/core/codegen/src/attribute/route/mod.rs
+++ b/core/codegen/src/attribute/route/mod.rs
@@ -209,9 +209,11 @@ fn internal_uri_macro_decl(route: &Route) -> TokenStream {
     // Generate a unique macro name based on the route's metadata.
     let macro_name = route.handler.sig.ident.prepend(crate::URI_MACRO_PREFIX);
     let inner_macro_name = macro_name.uniqueify_with(|mut hasher| {
-        route.handler.sig.ident.hash(&mut hasher);
+        route.attr.method.0.hash(&mut hasher);
         route.attr.uri.path().hash(&mut hasher);
-        route.attr.uri.query().hash(&mut hasher)
+        route.attr.uri.query().hash(&mut hasher);
+        route.attr.data.as_ref().map(|d| d.value.hash(&mut hasher));
+        route.attr.format.as_ref().map(|f| f.0.hash(&mut hasher));
     });
 
     let route_uri = route.attr.uri.to_string();

--- a/core/codegen/tests/route-uniqueness.rs
+++ b/core/codegen/tests/route-uniqueness.rs
@@ -1,0 +1,72 @@
+#[macro_use] extern crate rocket;
+
+#[get("/")]
+fn index() { }
+
+mod module {
+    // This one has all the same macro inputs, and we need it to
+    // generate a crate-wide unique identifier for the macro it
+    // defines.
+    #[get("/")]
+    pub fn index() { }
+}
+
+// Makes sure that the hashing of the proc macro's call site span
+// is enough, even if we're inside a declarative macro
+macro_rules! gen_routes {
+    () => {
+        #[get("/")]
+        pub fn index() { }
+
+        pub mod two {
+            #[get("/")]
+            pub fn index() { }
+        }
+    }
+}
+
+mod module2 {
+    gen_routes!();
+
+    pub mod module3 {
+        gen_routes!();
+    }
+}
+
+#[test]
+fn test_uri_reachability() {
+    use rocket::http::Status;
+    use rocket::local::blocking::Client;
+
+    let rocket = rocket::build()
+        .mount("/", routes![index])
+        .mount("/module", routes![module::index])
+        .mount("/module2", routes![module2::index])
+        .mount("/module2/two", routes![module2::two::index])
+        .mount("/module2/module3", routes![module2::module3::index])
+        .mount("/module2/module3/two", routes![module2::module3::two::index]);
+
+    let uris = rocket.routes()
+        .map(|r| r.uri.base().to_string())
+        .collect::<Vec<_>>();
+
+    let client = Client::debug(rocket).unwrap();
+    for uri in uris {
+        let response = client.get(uri).dispatch();
+        assert_eq!(response.status(), Status::Ok);
+    }
+}
+
+#[test]
+fn test_uri_calls() {
+    let uris = [
+        uri!(index()),
+        uri!(module::index()),
+        uri!(module2::index()),
+        uri!(module2::two::index()),
+        uri!(module2::module3::index()),
+        uri!(module2::module3::two::index()),
+    ];
+
+    assert!(uris.iter().all(|uri| uri == "/"));
+}


### PR DESCRIPTION
### Overview

In a nutshell, some slightly exotic ways of compiling rocket with rustc fail due to nondeterminism in `rocket_codegen` leading to rustc correctly noticing that you've compiled two incompatible versions of `rocket`. The nondeterminsim is in `IdentExt::uniqueify_with`.

I believe you can fix this by just doing it deterministically. I don't think it needs to be random. Reviewers please help determine if the things that are hashed for the route macro are enough to avoid collisions in the generated code. Specifically these. My gut feeling is you will also want the HTTP method to be hashed.

https://github.com/rwf2/Rocket/blob/2a1afd12f57ca435cf9018ddb08051bdc31aef6e/core/codegen/src/attribute/route/mod.rs#L211-L215

### Background -- rocket

See this for why random identifiers are being generated at all. https://github.com/rwf2/Rocket/pull/964

It currently does so using a combination of
- [a bunch of nondeterministic inputs](https://github.com/rwf2/Rocket/blob/2a1afd12f57ca435cf9018ddb08051bdc31aef6e/core/codegen/src/syn_ext.rs#L85-L94) including the random initialisation of DefaultHasher, process id, thread id, a racy atomic incrementing counter.

and some deterministic ones
- like the [path, query and handler function name of a `#[route]` macro](https://github.com/rwf2/Rocket/blob/2a1afd12f57ca435cf9018ddb08051bdc31aef6e/core/codegen/src/attribute/route/mod.rs#L211-L215)
- or the macro name for `rocket_codegen::export! { macro_rules! name {... } }`

The randomness seems like someone tried really hard to make it as random as possible. I don't think anything but the DefaultHasher's initialization was necessary to achieve that, and I put it to you that no randomness is required at all.

### Background -- rustc

- rustc hashes crates as it compiles them. It produces a "Strict Version Hash" that basically hashes the entire source code and every identifier, `--cfg` flag, `--Cmetadata` flag, all the dependencies, or something like that.
- The crucial thing is that it hashes every identifier
- Making random identifiers will produce a different SVH if you compile rocket twice with the exact same flags

My particular circumstances that led to experiencing this issue are:
- Not using cargo
- Using buck2 instead
- Buck2 does two compile passes with `rustc` on every crate -- one for metadata only, and one for codegen.
    - Cargo does not, rather `cargo check` metadata is not reused for `cargo build` and when you do run `cargo build`, the metadata + codegen outputs are produced during the same rustc invocation. (Incidentally this is why running `cargo check` does not make a subsequent `cargo build` any faster.)
- A library crate linking to rocket (the metadata build)
- A binary crate linking to rocket (the full codegen build, with a different SVH)

The build errors you get look like `found possibly newer version of crate rocket which thing depends on`. Almost all of the mentions of this error online are due to people compiling libstd / libcore from scratch and linking the wrong version, or compiler developers mixing different stages. Rustc does very reliably compute SVH, so generally when it's telling you this, it's not lying.

### Side note

Apart from the build failure, not ever being able to build identical copies of rocket / rocket applications is a problem if your build tool does caching and yeets the build products off to be used on other machines. That's a whole other can of beans.

### Illustration

Not a repro because too many steps and buck2 is complicated. But I reduced rocket down to a few lines of code to discover the cause of the build failure, so may as well show you.

![image](https://github.com/rwf2/Rocket/assets/378760/cc46367a-b0ce-420e-a30b-9e13cc0673bf)

```rust
// rocket_src.rs
rocket_codegen::export! {
    macro_rules! some_macro {
        () => {};
    }
}
pub mod request {}
```

```rust
// lib.rs
pub use rocket::request;
```

```rust
// main.rs
// You get a more informative error by writing out the `extern crate`s
extern crate thing;
extern crate rocket;
fn main() {}
```

Notable compile steps:

```sh
# metadata
rustc rocket_src.rs --crate-name=rocket_src --crate-type=rlib -Zno-codegen ...

# codegen
rustc rocket_src.rs --crate-name=rocket_src --crate-type=rlib ...

# library build links to the metadata (rlib-pic-static_pic-metadata-full/...)
rustc lib.rs --crate-name=thing --crate-type=rlib
--extern=rocket_src=buck-out/v2/gen/root/5c688cbd5131fe95/thing/rocket_src/__rocket_src__/rlib-pic-static_pic-metadata-full/librocket_src-6901b3c9.rlib

# binary build links to the codegen (rlib-pic-static_pic-link/...)
rustc main.rs --crate-type=bin
--extern=rocket_src=buck-out/v2/gen/root/5c688cbd5131fe95/thing/rocket_src/__rocket_src__/rlib-pic-static_pic-link/librocket_src-6901b3c9.rlib
```

And the binary build fails as below:

```
error[E0460]: found possibly newer version of crate `rocket_src` which `thing` depends on
 --> ./main.rs:1:1
  |
1 | extern crate thing;
  | ^^^^^^^^^^^^^^^^^^^
  |
  = note: perhaps that crate needs to be recompiled?
  = note: the following crate versions were found:
          crate `rocket_src`: .../buck-out/v2/gen/root/5c688cbd5131fe95/thing/rocket_src/__rocket_src__/rlib-pic-static_pic-link/librocket_src-6901b3c9.rlib
          crate `thing`: .../buck-out/v2/gen/root/5c688cbd5131fe95/thing/__thing__/rlib-pic-static_pic-link/libthing-16aa3fe0.rlib
```

