### PR TITLE
Encrypt data with secret key

### DIFF
--- a/core/lib/Cargo.toml
+++ b/core/lib/Cargo.toml
@@ -74,6 +74,8 @@ tokio-stream = { version = "0.1.6", features = ["signal", "time"] }
 cookie = { version = "0.18", features = ["percent-encode"] }
 futures = { version = "0.3.30", default-features = false, features = ["std"] }
 state = "0.6"
+aes-gcm = "0.10.3"
+base64 = "0.22.1"
 
 # tracing
 tracing = { version = "0.1.40", default-features = false, features = ["std", "attributes"] }

--- a/core/lib/Cargo.toml
+++ b/core/lib/Cargo.toml
@@ -77,6 +77,8 @@ state = "0.6"
 chacha20poly1305 = "0.10.1"
 hkdf = "0.12.4"
 sha2 = "0.10.8"
+base64 = "0.22.1"
+hex = "0.4.3"
 
 # tracing
 tracing = { version = "0.1.40", default-features = false, features = ["std", "attributes"] }

--- a/core/lib/Cargo.toml
+++ b/core/lib/Cargo.toml
@@ -74,7 +74,7 @@ tokio-stream = { version = "0.1.6", features = ["signal", "time"] }
 cookie = { version = "0.18", features = ["percent-encode"] }
 futures = { version = "0.3.30", default-features = false, features = ["std"] }
 state = "0.6"
-aes-gcm = "0.10.3"
+chacha20poly1305 = "0.10.1"
 
 # tracing
 tracing = { version = "0.1.40", default-features = false, features = ["std", "attributes"] }

--- a/core/lib/Cargo.toml
+++ b/core/lib/Cargo.toml
@@ -75,7 +75,6 @@ cookie = { version = "0.18", features = ["percent-encode"] }
 futures = { version = "0.3.30", default-features = false, features = ["std"] }
 state = "0.6"
 aes-gcm = "0.10.3"
-base64 = "0.22.1"
 
 # tracing
 tracing = { version = "0.1.40", default-features = false, features = ["std", "attributes"] }

--- a/core/lib/Cargo.toml
+++ b/core/lib/Cargo.toml
@@ -75,6 +75,8 @@ cookie = { version = "0.18", features = ["percent-encode"] }
 futures = { version = "0.3.30", default-features = false, features = ["std"] }
 state = "0.6"
 chacha20poly1305 = "0.10.1"
+hkdf = "0.12.4"
+sha2 = "0.10.8"
 
 # tracing
 tracing = { version = "0.1.40", default-features = false, features = ["std", "attributes"] }

--- a/core/lib/Cargo.toml
+++ b/core/lib/Cargo.toml
@@ -26,7 +26,7 @@ workspace = true
 default = ["http2", "tokio-macros", "trace"]
 http2 = ["hyper/http2", "hyper-util/http2"]
 http3-preview = ["s2n-quic", "s2n-quic-h3", "tls"]
-secrets = ["cookie/private", "cookie/key-expansion"]
+secrets = ["cookie/private", "cookie/key-expansion", "chacha20poly1305", "hkdf", "sha2", "base64", "hex"]
 json = ["serde_json"]
 msgpack = ["rmp-serde"]
 uuid = ["uuid_", "rocket_http/uuid"]
@@ -43,6 +43,13 @@ uuid_ = { package = "uuid", version = "1", optional = true, features = ["serde"]
 
 # Optional MTLS dependencies
 x509-parser = { version = "0.16", optional = true }
+
+# Optional dependencies for "secrets" feature
+chacha20poly1305 = { version = "0.10.1", optional = true }
+hkdf = { version = "0.12.4", optional = true }
+sha2 = { version = "0.10.8", optional = true }
+base64 = { version = "0.22.1", optional = true }
+hex = { version = "0.4.3", optional = true }
 
 # Hyper dependencies
 http = "1"
@@ -74,11 +81,6 @@ tokio-stream = { version = "0.1.6", features = ["signal", "time"] }
 cookie = { version = "0.18", features = ["percent-encode"] }
 futures = { version = "0.3.30", default-features = false, features = ["std"] }
 state = "0.6"
-chacha20poly1305 = "0.10.1"
-hkdf = "0.12.4"
-sha2 = "0.10.8"
-base64 = "0.22.1"
-hex = "0.4.3"
 
 # tracing
 tracing = { version = "0.1.40", default-features = false, features = ["std", "attributes"] }

--- a/core/lib/src/config/mod.rs
+++ b/core/lib/src/config/mod.rs
@@ -138,4 +138,4 @@ mod secret_key;
 pub use crate::shutdown::Sig;
 
 #[cfg(feature = "secrets")]
-pub use secret_key::SecretKey;
+pub use secret_key::{SecretKey, Cipher};

--- a/core/lib/src/config/secret_key.rs
+++ b/core/lib/src/config/secret_key.rs
@@ -268,11 +268,11 @@ impl SecretKey {
         Ok(Cipher(encrypted_data))
     }
 
-    /// Decrypts the given encrypted data.
+    /// Decrypts the given encrypted data, encapsulated in a Cipher wrapper.
     /// Extracts the nonce from the data and uses it for decryption.
     /// Returns the decrypted Vec<u8>.
-    pub fn decrypt<T: AsRef<[u8]>>(&self, encrypted: T) -> Result<Vec<u8>, Error> {
-        let encrypted = encrypted.as_ref();
+    pub fn decrypt(&self, encrypted: &Cipher) -> Result<Vec<u8>, Error> {
+        let encrypted = encrypted.as_bytes();
 
         // Check if the length of decoded data is at least the length of the nonce
         let nonce_len = <XChaCha20Poly1305 as AeadCore>::NonceSize::USIZE;
@@ -431,11 +431,5 @@ impl Cipher {
 impl fmt::Display for Cipher {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.to_base64())
-    }
-}
-
-impl AsRef<[u8]> for Cipher {
-    fn as_ref(&self) -> &[u8] {
-        self.as_bytes()
     }
 }

--- a/core/lib/src/config/secret_key.rs
+++ b/core/lib/src/config/secret_key.rs
@@ -194,9 +194,9 @@ impl SecretKey {
         ser.serialize_bytes(&[0; 32][..])
     }
 
-    /// Encrypts the given plaintext.
+    /// Encrypts the given data.
     /// Generates a random nonce for each encryption to ensure uniqueness.
-    /// Returns the base64-encoded string of the concatenated nonce and ciphertext.
+    /// Returns the Vec<u8> of the concatenated nonce and ciphertext.
     ///
     /// # Example
     /// ```rust
@@ -237,9 +237,9 @@ impl SecretKey {
         Ok(encrypted_data)
     }
 
-    /// Decrypts the given base64-encoded encrypted data.
+    /// Decrypts the given encrypted data.
     /// Extracts the nonce from the data and uses it for decryption.
-    /// Returns the decrypted plaintext string.
+    /// Returns the decrypted Vec<u8>.
     pub fn decrypt<T: AsRef<[u8]>>(&self, encrypted: T) -> Result<Vec<u8>, Error> {
         let encrypted = encrypted.as_ref();
 

--- a/core/lib/tests/private-data.rs
+++ b/core/lib/tests/private-data.rs
@@ -3,7 +3,20 @@
 
 #[cfg(test)]
 mod cookies_private_tests {
-    use rocket::config::SecretKey;
+    use rocket::config::{SecretKey, Cipher};
+
+    #[test]
+    fn cipher_conversions() {
+        let secret_key = SecretKey::generate().unwrap();
+
+        let plaintext = "I like turtles";
+        let cipher = secret_key.encrypt(plaintext).unwrap();
+
+        assert_eq!(cipher, Cipher::from_bytes(&cipher.as_bytes()));
+        assert_eq!(cipher, Cipher::from_vec(cipher.clone().into_vec()));
+        assert_eq!(cipher, Cipher::from_hex(&cipher.to_hex()).unwrap());
+        assert_eq!(cipher, Cipher::from_base64(&cipher.to_base64()).unwrap());
+    }
 
     #[test]
     fn encrypt_decrypt() {

--- a/core/lib/tests/private-data.rs
+++ b/core/lib/tests/private-data.rs
@@ -1,0 +1,36 @@
+#![cfg(feature = "secrets")]
+#![deny(warnings)]
+
+#[cfg(test)]
+mod cookies_private_tests {
+    use rocket::config::SecretKey;
+
+    #[test]
+    fn encrypt_decrypt() {
+        let secret_key = SecretKey::generate().unwrap();
+        
+        // encrypt byte array
+        let msg = "very-secret-message".as_bytes();
+        let encrypted = secret_key.encrypt(&msg).unwrap();
+        let decrypted = secret_key.decrypt(&encrypted).unwrap();
+        assert_eq!(msg, decrypted);
+
+        // encrypt String
+        let msg = "very-secret-message".to_string();
+        let encrypted = secret_key.encrypt(&msg).unwrap();
+        let decrypted = secret_key.decrypt(&encrypted).unwrap();
+        assert_eq!(msg.as_bytes(), decrypted);
+    }
+
+    #[test]
+    fn encrypt_with_wrong_key() {
+        let msg = "very-secret-message".as_bytes();
+
+        let secret_key = SecretKey::generate().unwrap();
+        let encrypted = secret_key.encrypt(msg).unwrap();
+
+        let another_secret_key = SecretKey::generate().unwrap();
+        let result = another_secret_key.decrypt(&encrypted);
+        assert!(result.is_err());
+    }
+}

--- a/core/lib/tests/private-data.rs
+++ b/core/lib/tests/private-data.rs
@@ -8,7 +8,7 @@ mod cookies_private_tests {
     #[test]
     fn encrypt_decrypt() {
         let secret_key = SecretKey::generate().unwrap();
-        
+
         // encrypt byte array
         let msg = "very-secret-message".as_bytes();
         let encrypted = secret_key.encrypt(&msg).unwrap();

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -17,8 +17,8 @@ members = [
   "testing",
   "tls",
   "upgrade",
-
   "pastebin",
   "todo",
   "chat",
+  "private-data",
 ]

--- a/examples/cookies/Rocket.toml
+++ b/examples/cookies/Rocket.toml
@@ -1,3 +1,2 @@
 [default]
-secret_key = "itlYmFR2vYKrOmFhupMIn/hyB6lYCCTXz4yaQX89XVg="
 template_dir = "templates"

--- a/examples/private-data/Cargo.toml
+++ b/examples/private-data/Cargo.toml
@@ -7,3 +7,4 @@ publish = false
 
 [dependencies]
 rocket = { path = "../../core/lib", features = ["secrets"] }
+base64 = "0.22.1"

--- a/examples/private-data/Cargo.toml
+++ b/examples/private-data/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "private-data"
+version = "0.0.0"
+workspace = "../"
+edition = "2021"
+publish = false
+
+[dependencies]
+rocket = { path = "../../core/lib", features = ["secrets"] }

--- a/examples/private-data/Cargo.toml
+++ b/examples/private-data/Cargo.toml
@@ -7,4 +7,3 @@ publish = false
 
 [dependencies]
 rocket = { path = "../../core/lib", features = ["secrets"] }
-base64 = "0.22.1"

--- a/examples/private-data/Rocket.toml
+++ b/examples/private-data/Rocket.toml
@@ -1,0 +1,2 @@
+[default]
+secret_key = "itlYmFR2vYKrOmFhupMIn/hyB6lYCCTXz4yaQX89XVg="

--- a/examples/private-data/Rocket.toml
+++ b/examples/private-data/Rocket.toml
@@ -1,2 +1,0 @@
-[default]
-secret_key = "itlYmFR2vYKrOmFhupMIn/hyB6lYCCTXz4yaQX89XVg="

--- a/examples/private-data/src/main.rs
+++ b/examples/private-data/src/main.rs
@@ -1,0 +1,36 @@
+#[macro_use]
+extern crate rocket;
+
+use rocket::{Config, State};
+use rocket::fairing::AdHoc;
+
+#[cfg(test)] mod tests;
+
+#[get("/encrypt/<msg>")]
+fn encrypt_endpoint(msg: &str, config: &State<Config>) -> String{
+    let secret_key = config.secret_key.clone();
+    let encrypted = secret_key.encrypt(msg).unwrap();
+
+    info!("received message for encrypt: '{}'", msg);
+    info!("encrypted msg: '{}'", encrypted);
+
+    encrypted
+}
+
+#[get("/decrypt/<msg>")]
+    fn decrypt_endpoint(msg: &str, config: &State<Config>) -> String {
+        let secret_key = config.secret_key.clone();
+        let decrypted = secret_key.decrypt(msg).unwrap();
+
+        info!("received message for decrypt: '{}'", msg);
+        info!("decrypted msg: '{}'", decrypted);
+
+    decrypted
+}
+
+#[launch]
+fn rocket() -> _ {
+    rocket::build()
+        .mount("/", routes![encrypt_endpoint, decrypt_endpoint])
+        .attach(AdHoc::config::<Config>())
+}

--- a/examples/private-data/src/main.rs
+++ b/examples/private-data/src/main.rs
@@ -3,29 +3,49 @@ extern crate rocket;
 
 use rocket::{Config, State};
 use rocket::fairing::AdHoc;
+use rocket::response::status;
+use rocket::http::Status;
+use base64::{engine::general_purpose::URL_SAFE, Engine as _};
 
 #[cfg(test)] mod tests;
 
 #[get("/encrypt/<msg>")]
-fn encrypt_endpoint(msg: &str, config: &State<Config>) -> String{
+fn encrypt_endpoint(msg: &str, config: &State<Config>) -> Result<String, status::Custom<String>> {
     let secret_key = config.secret_key.clone();
-    let encrypted = secret_key.encrypt(msg).unwrap();
+
+    let encrypted = secret_key.encrypt(msg).map_err(|_| {
+        status::Custom(Status::InternalServerError, "Failed to encrypt message".to_string())
+    })?;
+
+    let encrypted_msg = URL_SAFE.encode(&encrypted);
 
     info!("received message for encrypt: '{}'", msg);
-    info!("encrypted msg: '{}'", encrypted);
+    info!("encrypted msg: '{}'", encrypted_msg);
 
-    encrypted
+    Ok(encrypted_msg)
 }
 
 #[get("/decrypt/<msg>")]
-    fn decrypt_endpoint(msg: &str, config: &State<Config>) -> String {
-        let secret_key = config.secret_key.clone();
-        let decrypted = secret_key.decrypt(msg).unwrap();
+fn decrypt_endpoint(msg: &str, config: &State<Config>) -> Result<String, status::Custom<String>> {
+    let secret_key = config.secret_key.clone();
 
-        info!("received message for decrypt: '{}'", msg);
-        info!("decrypted msg: '{}'", decrypted);
+    let decoded = URL_SAFE.decode(msg).map_err(|_| {
+        status::Custom(Status::BadRequest, "Failed to decode base64".to_string())
+    })?;
 
-    decrypted
+    let decrypted = secret_key.decrypt(&decoded).map_err(|_| {
+        status::Custom(Status::InternalServerError, "Failed to decrypt message".to_string())
+    })?;
+
+    let decrypted_msg = String::from_utf8(decrypted).map_err(|_| {
+        status::Custom(Status::InternalServerError,
+        "Failed to convert decrypted message to UTF-8".to_string())
+    })?;
+
+    info!("received message for decrypt: '{}'", msg);
+    info!("decrypted msg: '{}'", decrypted_msg);
+
+    Ok(decrypted_msg)
 }
 
 #[launch]

--- a/examples/private-data/src/tests.rs
+++ b/examples/private-data/src/tests.rs
@@ -1,0 +1,12 @@
+use rocket::local::blocking::Client;
+
+#[test]
+fn encrypt_decrypt() {
+    let client = Client::tracked(super::rocket()).unwrap();
+    let msg = "some-secret-message";
+
+    let encrypted = client.get(format!("/encrypt/{}", msg)).dispatch().into_string().unwrap();
+    let decrypted = client.get(format!("/decrypt/{}", encrypted)).dispatch().into_string().unwrap();
+
+    assert_eq!(msg, decrypted);
+}

--- a/examples/private-data/src/tests.rs
+++ b/examples/private-data/src/tests.rs
@@ -1,7 +1,18 @@
-use rocket::local::blocking::Client;
+use rocket::{config::SecretKey, local::blocking::Client};
 
 #[test]
 fn encrypt_decrypt() {
+    let secret_key = SecretKey::generate().unwrap();
+    let msg = "very-secret-message".as_bytes();
+
+    let encrypted = secret_key.encrypt(msg).unwrap();
+    let decrypted = secret_key.decrypt(&encrypted).unwrap();
+
+    assert_eq!(msg, decrypted);
+}
+
+#[test]
+fn encrypt_decrypt_api() {
     let client = Client::tracked(super::rocket()).unwrap();
     let msg = "some-secret-message";
 


### PR DESCRIPTION
Implements encryption and decryption functions for arbitrary textual data, as discussed in #477.

- Added functions `encrypt` and `decrypt` to `SecretKey`.
- AAD is not used since we don't have metadata like cookie names.
- Functions for encryption/decryption are based on implementations from [cookie-rs](https://github.com/rwf2/cookie-rs/blob/master/src/secure/private.rs#L42-L88).
- Added example with suggested usage.
