### PR TITLE
Fix broken documentation links in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,8 @@ Rocket is extensively documented:
   * [Guide]: A detailed guide and reference to Rocket.
   * [API Documentation]: The "rustdocs".
 
-[Quickstart]: https://rocket.rs/guide/quickstart
-[Getting Started]: https://rocket.rs/guide/getting-started
+[Quickstart]: https://rocket.rs/guide/v0.5/quickstart/
+[Getting Started]: https://rocket.rs/guide/v0.5/getting-started/
 [Overview]: https://rocket.rs/overview/
 [Guide]: https://rocket.rs/guide/
 [API Documentation]: https://api.rocket.rs


### PR DESCRIPTION
This is a tiny fix that could be super helpful to some users, as it modifies the documentation links to be correct.

Since the frontend changed its links to be sectioned by Rocket version, the _Quickstart_ and _Getting Started_ pages moved. 

## Unrelated README Nit-Pick

Also, I noticed that the README example still uses `#[macro_use] extern crate` syntax, which is years out of date at this point. It was used to indicate to the compiler that there were macros to import, but past the 2021 Edition, it isn't necessary. 

Now, it just imports all macros from a crate, but these can be shadowed by any other item, and users won't really understand what's going on because it's uncommon. It's not great practice to include `#[macro_use]` for that reason.

I'm happy to replace that usage if you'd like! :)