### PR TITLE
Typed catchers

### DIFF
--- a/contrib/db_pools/codegen/src/database.rs
+++ b/contrib/db_pools/codegen/src/database.rs
@@ -60,15 +60,15 @@ pub fn derive_database(input: TokenStream) -> TokenStream {
 
                     #[rocket::async_trait]
                     impl<'r> rocket::request::FromRequest<'r> for &'r #decorated_type {
-                        type Error = ();
+                        type Error = rocket::http::Status;
 
                         async fn from_request(
                             req: &'r rocket::request::Request<'_>
                         ) -> rocket::request::Outcome<Self, Self::Error> {
                             match #db_ty::fetch(req.rocket()) {
                                 Some(db) => rocket::outcome::Outcome::Success(db),
-                                None => rocket::outcome::Outcome::Error((
-                                    rocket::http::Status::InternalServerError, ()))
+                                None => rocket::outcome::Outcome::Error(
+                                    rocket::http::Status::InternalServerError)
                             }
                         }
                     }

--- a/contrib/db_pools/codegen/src/database.rs
+++ b/contrib/db_pools/codegen/src/database.rs
@@ -60,11 +60,12 @@ pub fn derive_database(input: TokenStream) -> TokenStream {
 
                     #[rocket::async_trait]
                     impl<'r> rocket::request::FromRequest<'r> for &'r #decorated_type {
+                        type Forward = ::std::convert::Infallible;
                         type Error = rocket::http::Status;
 
                         async fn from_request(
                             req: &'r rocket::request::Request<'_>
-                        ) -> rocket::request::Outcome<Self, Self::Error> {
+                        ) -> rocket::request::Outcome<Self, Self::Error, Self::Forward> {
                             match #db_ty::fetch(req.rocket()) {
                                 Some(db) => rocket::outcome::Outcome::Success(db),
                                 None => rocket::outcome::Outcome::Error(

--- a/contrib/db_pools/lib/src/database.rs
+++ b/contrib/db_pools/lib/src/database.rs
@@ -1,3 +1,4 @@
+use std::convert::Infallible;
 use std::marker::PhantomData;
 use std::ops::{Deref, DerefMut};
 
@@ -301,9 +302,10 @@ impl<'r, E: Send + Sync + 'static> TypedError<'r> for DbError<E> {
 impl<'r, D: Database> FromRequest<'r> for Connection<D>
     where <D::Pool as Pool>::Error: Send + Sync + 'static
 {
+    type Forward = Infallible;
     type Error = DbError<<D::Pool as Pool>::Error>;
 
-    async fn from_request(req: &'r Request<'_>) -> Outcome<Self, Self::Error> {
+    async fn from_request(req: &'r Request<'_>) -> Outcome<Self, Self::Error, Infallible> {
         match D::fetch(req.rocket()) {
             Some(db) => match db.get().await {
                 Ok(conn) => Outcome::Success(Connection(conn)),

--- a/contrib/db_pools/lib/src/database.rs
+++ b/contrib/db_pools/lib/src/database.rs
@@ -1,6 +1,7 @@
 use std::marker::PhantomData;
 use std::ops::{Deref, DerefMut};
 
+use rocket::catcher::{Static, TypedError};
 use rocket::{error, Build, Ignite, Phase, Rocket, Sentinel, Orbit};
 use rocket::fairing::{self, Fairing, Info, Kind};
 use rocket::request::{FromRequest, Outcome, Request};
@@ -278,17 +279,37 @@ impl<D: Database> Fairing for Initializer<D> {
     }
 }
 
+/// Possible errors when aquiring a database connection
+#[derive(Debug, PartialEq, Eq)]
+pub enum DbError<E> {
+    ServiceUnavailable(E),
+    InternalError,
+}
+
+impl<E: 'static> Static for DbError<E> {}
+
+impl<'r, E: Send + Sync + 'static> TypedError<'r> for DbError<E> {
+    fn status(&self) -> Status {
+        match self {
+            Self::ServiceUnavailable(_) => Status::ServiceUnavailable,
+            Self::InternalError => Status::InternalServerError,
+        }
+    }
+}
+
 #[rocket::async_trait]
-impl<'r, D: Database> FromRequest<'r> for Connection<D> {
-    type Error = Option<<D::Pool as Pool>::Error>;
+impl<'r, D: Database> FromRequest<'r> for Connection<D>
+    where <D::Pool as Pool>::Error: Send + Sync + 'static
+{
+    type Error = DbError<<D::Pool as Pool>::Error>;
 
     async fn from_request(req: &'r Request<'_>) -> Outcome<Self, Self::Error> {
         match D::fetch(req.rocket()) {
             Some(db) => match db.get().await {
                 Ok(conn) => Outcome::Success(Connection(conn)),
-                Err(e) => Outcome::Error((Status::ServiceUnavailable, Some(e))),
+                Err(e) => Outcome::Error(DbError::ServiceUnavailable(e)),
             },
-            None => Outcome::Error((Status::InternalServerError, None)),
+            None => Outcome::Error(DbError::InternalError),
         }
     }
 }

--- a/contrib/dyn_templates/src/metadata.rs
+++ b/contrib/dyn_templates/src/metadata.rs
@@ -157,7 +157,9 @@ impl<'r> FromRequest<'r> for Metadata<'r> {
     type Forward = Infallible;
     type Error = StateError;
 
-    async fn from_request(request: &'r Request<'_>) -> request::Outcome<Self, Self::Error, Infallible> {
+    async fn from_request(request: &'r Request<'_>) ->
+        request::Outcome<Self, Self::Error, Infallible>
+    {
         match request.rocket().state::<ContextManager>() {
             Some(cm) => Outcome::Success(Metadata(cm)),
             None => {

--- a/contrib/dyn_templates/src/metadata.rs
+++ b/contrib/dyn_templates/src/metadata.rs
@@ -157,7 +157,7 @@ impl<'r> FromRequest<'r> for Metadata<'r> {
 
     async fn from_request(request: &'r Request<'_>) -> request::Outcome<Self, Self::Error> {
         match request.rocket().state::<ContextManager>() {
-            Some(cm) => Outcome::Success(cm),
+            Some(cm) => Outcome::Success(Metadata(cm)),
             None => {
                 error!(
                     "uninitialized template context: missing `Template::fairing()`.\n\

--- a/contrib/dyn_templates/src/metadata.rs
+++ b/contrib/dyn_templates/src/metadata.rs
@@ -3,7 +3,7 @@ use std::borrow::Cow;
 
 use rocket::outcome::Outcome;
 use rocket::{Ignite, Request, Rocket, Sentinel, StateMissing};
-use rocket::http::{Status, ContentType};
+use rocket::http::ContentType;
 use rocket::request::{self, FromRequest};
 use rocket::serde::Serialize;
 

--- a/contrib/dyn_templates/src/metadata.rs
+++ b/contrib/dyn_templates/src/metadata.rs
@@ -1,3 +1,4 @@
+use std::convert::Infallible;
 use std::fmt;
 use std::borrow::Cow;
 
@@ -153,9 +154,10 @@ impl Sentinel for Metadata<'_> {
 /// (`500`) is returned.
 #[rocket::async_trait]
 impl<'r> FromRequest<'r> for Metadata<'r> {
+    type Forward = Infallible;
     type Error = StateError;
 
-    async fn from_request(request: &'r Request<'_>) -> request::Outcome<Self, Self::Error> {
+    async fn from_request(request: &'r Request<'_>) -> request::Outcome<Self, Self::Error, Infallible> {
         match request.rocket().state::<ContextManager>() {
             Some(cm) => Outcome::Success(Metadata(cm)),
             None => {

--- a/contrib/dyn_templates/src/metadata.rs
+++ b/contrib/dyn_templates/src/metadata.rs
@@ -2,7 +2,7 @@ use std::fmt;
 use std::borrow::Cow;
 
 use rocket::outcome::Outcome;
-use rocket::{Ignite, Request, Rocket, Sentinel, StateMissing};
+use rocket::{Ignite, Request, Rocket, Sentinel, StateError};
 use rocket::http::ContentType;
 use rocket::request::{self, FromRequest};
 use rocket::serde::Serialize;
@@ -153,7 +153,7 @@ impl Sentinel for Metadata<'_> {
 /// (`500`) is returned.
 #[rocket::async_trait]
 impl<'r> FromRequest<'r> for Metadata<'r> {
-    type Error = StateMissing;
+    type Error = StateError;
 
     async fn from_request(request: &'r Request<'_>) -> request::Outcome<Self, Self::Error> {
         match request.rocket().state::<ContextManager>() {
@@ -164,7 +164,7 @@ impl<'r> FromRequest<'r> for Metadata<'r> {
                     To use templates, you must attach `Template::fairing()`."
                 );
 
-                request::Outcome::Error(StateMissing("Template::fairing()"))
+                request::Outcome::Error(StateError("Template::fairing()"))
             }
         }
     }

--- a/contrib/dyn_templates/src/template.rs
+++ b/contrib/dyn_templates/src/template.rs
@@ -265,7 +265,7 @@ impl Template {
 /// extension and a fixed-size body containing the rendered template. If
 /// rendering fails, an `Err` of `Status::InternalServerError` is returned.
 impl<'r> Responder<'r, 'static> for Template {
-    fn respond_to(self, req: &'r Request<'_>) -> response::Result<'static> {
+    fn respond_to(self, req: &'r Request<'_>) -> response::Result<'r, 'static> {
         let ctxt = req.rocket()
             .state::<ContextManager>()
             .ok_or_else(|| {

--- a/contrib/sync_db_pools/codegen/src/database.rs
+++ b/contrib/sync_db_pools/codegen/src/database.rs
@@ -112,11 +112,12 @@ pub fn database_attr(attr: TokenStream, input: TokenStream) -> Result<TokenStrea
 
         #[#rocket::async_trait]
         impl<'r> #rocket::request::FromRequest<'r> for #guard_type {
+            type Forward = ::std::convert::Infallible;
             type Error = ::rocket_sync_db_pools::ConnectionMissing;
 
             async fn from_request(
                 __r: &'r #rocket::request::Request<'_>
-            ) -> #rocket::request::Outcome<Self, Self::Error> {
+            ) -> #rocket::request::Outcome<Self, Self::Error, Self::Forward> {
                 <#conn>::from_request(__r).await.map(Self)
             }
         }

--- a/contrib/sync_db_pools/codegen/src/database.rs
+++ b/contrib/sync_db_pools/codegen/src/database.rs
@@ -112,11 +112,11 @@ pub fn database_attr(attr: TokenStream, input: TokenStream) -> Result<TokenStrea
 
         #[#rocket::async_trait]
         impl<'r> #rocket::request::FromRequest<'r> for #guard_type {
-            type Error = ();
+            type Error = ::rocket_sync_db_pools::ConnectionMissing;
 
             async fn from_request(
                 __r: &'r #rocket::request::Request<'_>
-            ) -> #rocket::request::Outcome<Self, ()> {
+            ) -> #rocket::request::Outcome<Self, Self::Error> {
                 <#conn>::from_request(__r).await.map(Self)
             }
         }

--- a/contrib/sync_db_pools/lib/src/connection.rs
+++ b/contrib/sync_db_pools/lib/src/connection.rs
@@ -1,4 +1,5 @@
 use std::any::type_name;
+use std::convert::Infallible;
 use std::sync::Arc;
 use std::marker::PhantomData;
 
@@ -235,10 +236,11 @@ impl<'r> TypedError<'r> for ConnectionMissing {
 
 #[rocket::async_trait]
 impl<'r, K: 'static, C: Poolable> FromRequest<'r> for Connection<K, C> {
+    type Forward = Infallible;
     type Error = ConnectionMissing;
 
     #[inline]
-    async fn from_request(request: &'r Request<'_>) -> Outcome<Self, Self::Error> {
+    async fn from_request(request: &'r Request<'_>) -> Outcome<Self, Self::Error, Infallible> {
         match request.rocket().state::<ConnectionPool<K, C>>() {
             Some(c) => c.get().await.or_error(ConnectionMissing(type_name::<K>())),
             None => {

--- a/contrib/ws/src/websocket.rs
+++ b/contrib/ws/src/websocket.rs
@@ -213,7 +213,7 @@ pub struct MessageStream<'r, S> {
 
 #[rocket::async_trait]
 impl<'r> FromRequest<'r> for WebSocket {
-    type Error = std::convert::Infallible;
+    type Error = Status;
 
     async fn from_request(req: &'r Request<'_>) -> Outcome<Self, Self::Error> {
         use crate::tungstenite::handshake::derive_accept_key;

--- a/contrib/ws/src/websocket.rs
+++ b/contrib/ws/src/websocket.rs
@@ -213,9 +213,10 @@ pub struct MessageStream<'r, S> {
 
 #[rocket::async_trait]
 impl<'r> FromRequest<'r> for WebSocket {
+    type Forward = Status;
     type Error = Status;
 
-    async fn from_request(req: &'r Request<'_>) -> Outcome<Self, Self::Error> {
+    async fn from_request(req: &'r Request<'_>) -> Outcome<Self, Self::Error, Self::Forward> {
         use crate::tungstenite::handshake::derive_accept_key;
         use rocket::http::uncased::eq;
 

--- a/contrib/ws/src/websocket.rs
+++ b/contrib/ws/src/websocket.rs
@@ -238,7 +238,7 @@ impl<'r> FromRequest<'r> for WebSocket {
 }
 
 impl<'r, 'o: 'r> Responder<'r, 'o> for Channel<'o> {
-    fn respond_to(self, _: &'r Request<'_>) -> response::Result<'o> {
+    fn respond_to(self, _: &'r Request<'_>) -> response::Result<'r, 'o> {
         Response::build()
             .raw_header("Sec-Websocket-Version", "13")
             .raw_header("Sec-WebSocket-Accept", self.ws.key.clone())
@@ -250,7 +250,7 @@ impl<'r, 'o: 'r> Responder<'r, 'o> for Channel<'o> {
 impl<'r, 'o: 'r, S> Responder<'r, 'o> for MessageStream<'o, S>
     where S: futures::Stream<Item = Result<Message>> + Send + 'o
 {
-    fn respond_to(self, _: &'r Request<'_>) -> response::Result<'o> {
+    fn respond_to(self, _: &'r Request<'_>) -> response::Result<'r, 'o> {
         Response::build()
             .raw_header("Sec-Websocket-Version", "13")
             .raw_header("Sec-WebSocket-Accept", self.ws.key.clone())

--- a/core/codegen/src/attribute/async_bound/mod.rs
+++ b/core/codegen/src/attribute/async_bound/mod.rs
@@ -15,7 +15,6 @@ fn _async_bound(
     }
 
     let mut func: TraitItemFn = syn::parse(input)?;
-    let original: TraitItemFn = func.clone();
     if func.sig.asyncness.is_none() {
         let diag = Span::call_site()
             .error("attribute can only be applied to async fns")
@@ -43,14 +42,7 @@ fn _async_bound(
     };
 
     Ok(quote! {
-        #[cfg(all(not(doc), rust_analyzer))]
-        #original
-
-        #[cfg(all(doc, not(rust_analyzer)))]
         #doc
-        #original
-
-        #[cfg(not(any(doc, rust_analyzer)))]
         #func
     })
 }

--- a/core/codegen/src/attribute/catch/mod.rs
+++ b/core/codegen/src/attribute/catch/mod.rs
@@ -61,7 +61,8 @@ pub fn _catch(
                     ::rocket::trace::error!(
                         downcast_to = stringify!(#ty),
                         error_name = #__error.name(),
-                        "Failed to downcast error. This should never happen, please open an issue with details."
+                        "Failed to downcast error. This should never happen, please \
+                        open an issue with details."
                     );
                     return #_Err(#Status::InternalServerError);
                 },

--- a/core/codegen/src/attribute/catch/mod.rs
+++ b/core/codegen/src/attribute/catch/mod.rs
@@ -31,8 +31,10 @@ pub fn _catch(
     let from_error = catch.guards.iter().map(|g| {
         let name = g.fn_ident.rocketized();
         let ty = g.ty.with_replaced_lifetimes(Lifetime::new("'__r", g.ty.span()));
-        quote_spanned!(g.span() => 
-            let #name: #ty = match <#ty as #FromError<'__r>>::from_error(#__status, #__req, #__error).await {
+        quote_spanned!(g.span() =>
+            let #name: #ty = match <
+                #ty as #FromError<'__r>
+            >::from_error(#__status, #__req, #__error).await {
                 #_Ok(v) => v,
                 #_Err(s) => {
                     // TODO: Typed: log failure
@@ -63,7 +65,7 @@ pub fn _catch(
             },
             _ => todo!("Invalid type"),
         };
-        quote_spanned!(g.span() => 
+        quote_spanned!(g.span() =>
             #_catcher::TypeId::of::<#ty>()
         )
     }));
@@ -76,7 +78,7 @@ pub fn _catch(
         let name = a.typed().unwrap().0.rocketized();
         quote!(#name)
     });
-    
+
     let catcher_response = quote_spanned!(return_type_span => {
         let ___responder = #user_catcher_fn_name(#(#args),*) #dot_await;
         #_response::Responder::respond_to(___responder, #__req).map_err(|e| e.status())?

--- a/core/codegen/src/attribute/catch/mod.rs
+++ b/core/codegen/src/attribute/catch/mod.rs
@@ -1,11 +1,12 @@
 mod parse;
 
-use devise::ext::SpanDiagnosticExt;
+use devise::ext::TypeExt;
 use devise::{Spanned, Result};
 use proc_macro2::{TokenStream, Span};
+use syn::{Lifetime, TypeReference};
 
 use crate::http_codegen::Optional;
-use crate::syn_ext::ReturnTypeExt;
+use crate::syn_ext::{FnArgExt, IdentExt, ReturnTypeExt};
 use crate::exports::*;
 
 pub fn _catch(
@@ -22,35 +23,63 @@ pub fn _catch(
     let status_code = Optional(catch.status.map(|s| s.code));
     let deprecated = catch.function.attrs.iter().find(|a| a.path().is_ident("deprecated"));
 
-    // Determine the number of parameters that will be passed in.
-    if catch.function.sig.inputs.len() > 2 {
-        return Err(catch.function.sig.paren_token.span.join()
-            .error("invalid number of arguments: must be zero, one, or two")
-            .help("catchers optionally take `&Request` or `Status, &Request`"));
-    }
-
     // This ensures that "Responder not implemented" points to the return type.
     let return_type_span = catch.function.sig.output.ty()
         .map(|ty| ty.span())
         .unwrap_or_else(Span::call_site);
 
-    // Set the `req` and `status` spans to that of their respective function
-    // arguments for a more correct `wrong type` error span. `rev` to be cute.
-    let codegen_args = &[__req, __status];
-    let inputs = catch.function.sig.inputs.iter().rev()
-        .zip(codegen_args.iter())
-        .map(|(fn_arg, codegen_arg)| match fn_arg {
-            syn::FnArg::Receiver(_) => codegen_arg.respanned(fn_arg.span()),
-            syn::FnArg::Typed(a) => codegen_arg.respanned(a.ty.span())
-        }).rev();
+    let from_error = catch.guards.iter().map(|g| {
+        let name = g.fn_ident.rocketized();
+        let ty = g.ty.with_replaced_lifetimes(Lifetime::new("'__r", g.ty.span()));
+        quote_spanned!(g.span() => 
+            let #name: #ty = match <#ty as #FromError<'__r>>::from_error(#__status, #__req, #__error).await {
+                #_Ok(v) => v,
+                #_Err(s) => {
+                    // TODO: Typed: log failure
+                    return #_Err(s);
+                },
+            };
+        )
+    });
+
+    let error = catch.error.iter().map(|g| {
+        let name = g.fn_ident.rocketized();
+        let ty = g.ty.with_replaced_lifetimes(Lifetime::new("'__r", g.ty.span()));
+        quote!(
+            let #name: #ty = match #_catcher::downcast(#__error) {
+                Some(v) => v,
+                None => {
+                    // TODO: Typed: log failure - this should never happen
+                    return #_Err(#Status::InternalServerError);
+                },
+            };
+        )
+    });
+
+    let error_type = Optional(catch.error.as_ref().map(|g| {
+        let ty = match &g.ty {
+            syn::Type::Reference(TypeReference { mutability: None, elem, .. }) => {
+                elem.as_ref().with_stripped_lifetimes()
+            },
+            _ => todo!("Invalid type"),
+        };
+        quote_spanned!(g.span() => 
+            #_catcher::TypeId::of::<#ty>()
+        )
+    }));
 
     // We append `.await` to the function call if this is `async`.
     let dot_await = catch.function.sig.asyncness
         .map(|a| quote_spanned!(a.span() => .await));
 
+    let args = catch.function.sig.inputs.iter().map(|a| {
+        let name = a.typed().unwrap().0.rocketized();
+        quote!(#name)
+    });
+    
     let catcher_response = quote_spanned!(return_type_span => {
-        let ___responder = #user_catcher_fn_name(#(#inputs),*) #dot_await;
-        #_response::Responder::respond_to(___responder, #__req)?
+        let ___responder = #user_catcher_fn_name(#(#args),*) #dot_await;
+        #_response::Responder::respond_to(___responder, #__req).map_err(|e| e.status())?
     });
 
     // Generate the catcher, keeping the user's input around.
@@ -68,9 +97,12 @@ pub fn _catch(
             fn into_info(self) -> #_catcher::StaticInfo {
                 fn monomorphized_function<'__r>(
                     #__status: #Status,
+                    #__error: &'__r dyn #TypedError<'__r>,
                     #__req: &'__r #Request<'_>
                 ) -> #_catcher::BoxFuture<'__r> {
                     #_Box::pin(async move {
+                        #(#from_error)*
+                        #(#error)*
                         let __response = #catcher_response;
                         #Response::build()
                             .status(#__status)
@@ -83,6 +115,7 @@ pub fn _catch(
                     name: ::core::stringify!(#user_catcher_fn_name),
                     code: #status_code,
                     handler: monomorphized_function,
+                    type_id: #error_type,
                     location: (::core::file!(), ::core::line!(), ::core::column!()),
                 }
             }

--- a/core/codegen/src/attribute/catch/mod.rs
+++ b/core/codegen/src/attribute/catch/mod.rs
@@ -78,7 +78,7 @@ pub fn _catch(
             _ => return Err(g.ty.span().error("invalid type, must be a reference")),
         };
         Ok(quote_spanned!(g.span() =>
-            #_catcher::TypeId::of::<#ty>()
+            (::std::any::type_name::<#ty>(), #_catcher::TypeId::of::<#ty>())
         ))
     }).transpose()?);
 
@@ -129,7 +129,7 @@ pub fn _catch(
                     name: ::core::stringify!(#user_catcher_fn_name),
                     code: #status_code,
                     handler: monomorphized_function,
-                    type_id: #error_type,
+                    type_info: #error_type,
                     location: (::core::file!(), ::core::line!(), ::core::column!()),
                 }
             }

--- a/core/codegen/src/attribute/catch/mod.rs
+++ b/core/codegen/src/attribute/catch/mod.rs
@@ -52,6 +52,7 @@ pub fn _catch(
                 Some(v) => v,
                 None => {
                     // TODO: Typed: log failure - this should never happen
+                    println!("Failed to downcast error {}", stringify!(#ty));
                     return #_Err(#Status::InternalServerError);
                 },
             };

--- a/core/codegen/src/attribute/catch/parse.rs
+++ b/core/codegen/src/attribute/catch/parse.rs
@@ -1,13 +1,21 @@
 use devise::ext::SpanDiagnosticExt;
-use devise::{MetaItem, Spanned, Result, FromMeta, Diagnostic};
+use devise::{Diagnostic, FromMeta, MetaItem, Result, SpanWrapped, Spanned};
 use proc_macro2::TokenStream;
 
+use crate::attribute::param::{Dynamic, Guard};
+use crate::name::Name;
+use crate::proc_macro_ext::Diagnostics;
+use crate::syn_ext::FnArgExt;
 use crate::{http, http_codegen};
 
 /// This structure represents the parsed `catch` attribute and associated items.
 pub struct Attribute {
     /// The status associated with the code in the `#[catch(code)]` attribute.
     pub status: Option<http::Status>,
+    /// The parameter to be used as the error type.
+    pub error: Option<Guard>,
+    /// All the other guards
+    pub guards: Vec<Guard>,
     /// The function that was decorated with the `catch` attribute.
     pub function: syn::ItemFn,
 }
@@ -17,6 +25,7 @@ pub struct Attribute {
 struct Meta {
     #[meta(naked)]
     code: Code,
+    error: Option<SpanWrapped<Dynamic>>,
 }
 
 /// `Some` if there's a code, `None` if it's `default`.
@@ -48,11 +57,41 @@ impl Attribute {
             .map_err(|diag| diag.help("`#[catch]` can only be used on functions"))?;
 
         let attr: MetaItem = syn::parse2(quote!(catch(#args)))?;
-        let status = Meta::from_meta(&attr)
-            .map(|meta| meta.code.0)
+        let meta = Meta::from_meta(&attr)
+            // .map(|meta| meta.code.0)
             .map_err(|diag| diag.help("`#[catch]` expects a status code int or `default`: \
                         `#[catch(404)]` or `#[catch(default)]`"))?;
 
-        Ok(Attribute { status, function })
+        let mut diags = Diagnostics::new();
+        let mut guards = Vec::new();
+        let mut error = None;
+        for (index, arg) in function.sig.inputs.iter().enumerate() {
+            if let Some((ident, ty)) = arg.typed() {
+                match meta.error.as_ref() {
+                    Some(err) if Name::from(ident) == err.name => {
+                        error = Some(Guard { source: meta.error.clone().unwrap().value, fn_ident: ident.clone(), ty: ty.clone() });
+                    }
+                    _ => {
+                        guards.push(Guard { source: Dynamic { name: Name::from(ident), index, trailing: false }, fn_ident: ident.clone(), ty: ty.clone() })
+                    }
+                }
+            } else {
+                let span = arg.span();
+                let diag = if arg.wild().is_some() {
+                    span.error("handler arguments must be named")
+                        .help("to name an ignored handler argument, use `_name`")
+                } else {
+                    span.error("handler arguments must be of the form `ident: Type`")
+                };
+
+                diags.push(diag);
+            }
+        }
+        if meta.error.is_some() != error.is_some() {
+            let span = meta.error.unwrap().span();
+            diags.push(span.error("Error parameter not found on function"));
+        }
+
+        diags.head_err_or(Attribute { status: meta.code.0, error, guards, function })
     }
 }

--- a/core/codegen/src/attribute/catch/parse.rs
+++ b/core/codegen/src/attribute/catch/parse.rs
@@ -69,10 +69,18 @@ impl Attribute {
             if let Some((ident, ty)) = arg.typed() {
                 match meta.error.as_ref() {
                     Some(err) if Name::from(ident) == err.name => {
-                        error = Some(Guard { source: meta.error.clone().unwrap().value, fn_ident: ident.clone(), ty: ty.clone() });
+                        error = Some(Guard {
+                            source: meta.error.clone().unwrap().value,
+                            fn_ident: ident.clone(),
+                            ty: ty.clone(),
+                        });
                     }
                     _ => {
-                        guards.push(Guard { source: Dynamic { name: Name::from(ident), index, trailing: false }, fn_ident: ident.clone(), ty: ty.clone() })
+                        guards.push(Guard {
+                            source: Dynamic { name: Name::from(ident), index, trailing: false },
+                            fn_ident: ident.clone(),
+                            ty: ty.clone(),
+                        })
                     }
                 }
             } else {

--- a/core/codegen/src/attribute/mod.rs
+++ b/core/codegen/src/attribute/mod.rs
@@ -1,3 +1,42 @@
+use devise::{ext::{SpanDiagnosticExt as _, TypeExt as _}, Spanned};
+use indexmap::IndexMap;
+use proc_macro2::Span;
+use syn::Signature;
+
+use crate::{name::Name, proc_macro_ext::Diagnostics, syn_ext::FnArgExt as _};
+
+type ArgumentMap = IndexMap<Name, (syn::Ident, syn::Type)>;
+
+#[derive(Debug)]
+pub struct Arguments {
+    pub span: Span,
+    pub map: ArgumentMap
+}
+
+impl Arguments {
+    pub fn from_signature(sig: &Signature, diags: &mut Diagnostics) -> Self {
+        let span = sig.paren_token.span.join();
+        let mut arguments = Self { span, map: ArgumentMap::new() };
+        for arg in &sig.inputs {
+            if let Some((ident, ty)) = arg.typed() {
+                let value = (ident.clone(), ty.with_stripped_lifetimes());
+                arguments.map.insert(Name::from(ident), value);
+            } else {
+                let span = arg.span();
+                let diag = if arg.wild().is_some() {
+                    span.error("handler arguments must be named")
+                        .help("to name an ignored handler argument, use `_name`")
+                } else {
+                    span.error("handler arguments must be of the form `ident: Type`")
+                };
+
+                diags.push(diag);
+            }
+        }
+        arguments
+    }
+}
+
 pub mod entry;
 pub mod catch;
 pub mod route;

--- a/core/codegen/src/attribute/route/mod.rs
+++ b/core/codegen/src/attribute/route/mod.rs
@@ -114,7 +114,10 @@ fn query_decls(route: &Route) -> Option<TokenStream> {
                         ); } }
                 );
 
-                return #Outcome::Forward((#__data, Box::new(__e) as Box<dyn #TypedError<'__r> + '__r>));
+                return #Outcome::Forward((
+                    #__data,
+                    Box::new(__e) as Box<dyn #TypedError<'__r> + '__r>
+                ));
             }
 
             (#(#ident.unwrap()),*)
@@ -141,7 +144,10 @@ fn request_guard_decl(guard: &Guard) -> TokenStream {
                     "request guard forwarding"
                 );
 
-                return #Outcome::Forward((#__data, Box::new(__e) as Box<dyn #TypedError<'__r> + '__r>));
+                return #Outcome::Forward((
+                    #__data,
+                    Box::new(__e) as Box<dyn #TypedError<'__r> + '__r>
+                ));
             },
             #[allow(unreachable_code)]
             #Outcome::Error(__c) => {
@@ -205,7 +211,10 @@ fn param_guard_decl(guard: &Guard) -> TokenStream {
                         #i
                     );
 
-                    return #Outcome::Forward((#__data, Box::new(#Status::InternalServerError) as Box<dyn #TypedError<'__r> + '__r>))
+                    return #Outcome::Forward((
+                        #__data,
+                        Box::new(#Status::InternalServerError) as Box<dyn #TypedError<'__r> + '__r>
+                    ));
                 }
             }
         },
@@ -242,7 +251,10 @@ fn data_guard_decl(guard: &Guard) -> TokenStream {
                     "data guard forwarding"
                 );
 
-                return #Outcome::Forward((__d, Box::new(__e) as Box<dyn #TypedError<'__r> + '__r>));
+                return #Outcome::Forward((
+                    __d,
+                    Box::new(__e) as Box<dyn #TypedError<'__r> + '__r>
+                ));
             }
             #[allow(unreachable_code)]
             #Outcome::Error(__e) => {

--- a/core/codegen/src/attribute/route/mod.rs
+++ b/core/codegen/src/attribute/route/mod.rs
@@ -113,6 +113,12 @@ fn query_decls(route: &Route) -> Option<TokenStream> {
                             "{_err}"
                         ); } }
                 );
+                ::rocket::trace::info!(
+                    name: "forward",
+                    target: concat!("rocket::codegen::route::", module_path!()),
+                    error_name = #TypedError::name(&__e),
+                    "parameter guard forwarding"
+                );
 
                 return #Outcome::Forward((
                     #__data,
@@ -141,6 +147,7 @@ fn request_guard_decl(guard: &Guard) -> TokenStream {
                     parameter = stringify!(#ident),
                     type_name = stringify!(#ty),
                     status = #TypedError::status(&__e).code,
+                    error_name = #TypedError::name(&__e),
                     "request guard forwarding"
                 );
 
@@ -156,8 +163,8 @@ fn request_guard_decl(guard: &Guard) -> TokenStream {
                     target: concat!("rocket::codegen::route::", module_path!()),
                     parameter = stringify!(#ident),
                     type_name = stringify!(#ty),
+                    status = #TypedError::status(&__c).code,
                     error_name = #TypedError::name(&__c),
-                    // reason = %#display_hack!(__e),
                     "request guard failed"
                 );
 
@@ -181,8 +188,7 @@ fn param_guard_decl(guard: &Guard) -> TokenStream {
             target: concat!("rocket::codegen::route::", module_path!()),
             parameter = #name,
             type_name = stringify!(#ty),
-            name = #TypedError::name(&__error),
-            // reason = %#display_hack!(__error),
+            error_name = #TypedError::name(&__error),
             "path guard forwarding"
         );
 
@@ -248,6 +254,7 @@ fn data_guard_decl(guard: &Guard) -> TokenStream {
                     parameter = stringify!(#ident),
                     type_name = stringify!(#ty),
                     status = #TypedError::status(&__e).code,
+                    error_name = #TypedError::name(&__e),
                     "data guard forwarding"
                 );
 
@@ -263,7 +270,7 @@ fn data_guard_decl(guard: &Guard) -> TokenStream {
                     target: concat!("rocket::codegen::route::", module_path!()),
                     parameter = stringify!(#ident),
                     type_name = stringify!(#ty),
-                    // reason = %#display_hack!(__e),
+                    error_name = #TypedError::name(&__e),
                     "data guard failed"
                 );
 

--- a/core/codegen/src/derive/mod.rs
+++ b/core/codegen/src/derive/mod.rs
@@ -4,3 +4,4 @@ pub mod from_form_field;
 pub mod responder;
 pub mod uri_display;
 pub mod from_param;
+pub mod typed_error;

--- a/core/codegen/src/derive/responder.rs
+++ b/core/codegen/src/derive/responder.rs
@@ -70,9 +70,7 @@ pub fn derive_responder(input: proc_macro::TokenStream) -> TokenStream {
         )
         .inner_mapper(MapperBuild::new()
             .with_output(|_, output| quote! {
-                fn respond_to(self, __req: &'r #Request<'_>)
-                    -> #_response::Result<'r, 'o>
-                {
+                fn respond_to(self, __req: &'r #Request<'_>) -> #_response::Result<'r, 'o> {
                     #output
                 }
             })

--- a/core/codegen/src/derive/responder.rs
+++ b/core/codegen/src/derive/responder.rs
@@ -1,3 +1,8 @@
+// use quote::ToTokens;
+// use crate::{exports::{*, Status as _Status}, syn_ext::IdentExt};
+// use devise::{*, ext::{TypeExt, SpanDiagnosticExt}};
+// use crate::http_codegen::{ContentType, Status};
+
 use quote::ToTokens;
 use devise::{*, ext::{TypeExt, SpanDiagnosticExt}};
 use proc_macro2::TokenStream;
@@ -6,12 +11,12 @@ use crate::exports::*;
 use crate::syn_ext::{TypeExt as _, GenericsExt as _};
 use crate::http_codegen::{ContentType, Status};
 
+
 #[derive(Debug, Default, FromMeta)]
 struct ItemAttr {
     content_type: Option<SpanWrapped<ContentType>>,
-    status: Option<SpanWrapped<Status>>,
+    status: Option<SpanWrapped<Status>>,            
 }
-
 #[derive(Default, FromMeta)]
 struct FieldAttr {
     ignore: bool,
@@ -65,7 +70,9 @@ pub fn derive_responder(input: proc_macro::TokenStream) -> TokenStream {
         )
         .inner_mapper(MapperBuild::new()
             .with_output(|_, output| quote! {
-                fn respond_to(self, __req: &'r #Request<'_>) -> #_response::Result<'o> {
+                fn respond_to(self, __req: &'r #Request<'_>)
+                    -> #_response::Result<'r, 'o>
+                {
                     #output
                 }
             })

--- a/core/codegen/src/derive/responder.rs
+++ b/core/codegen/src/derive/responder.rs
@@ -15,7 +15,7 @@ use crate::http_codegen::{ContentType, Status};
 #[derive(Debug, Default, FromMeta)]
 struct ItemAttr {
     content_type: Option<SpanWrapped<ContentType>>,
-    status: Option<SpanWrapped<Status>>,            
+    status: Option<SpanWrapped<Status>>,
 }
 #[derive(Default, FromMeta)]
 struct FieldAttr {

--- a/core/codegen/src/derive/typed_error.rs
+++ b/core/codegen/src/derive/typed_error.rs
@@ -1,0 +1,160 @@
+use devise::{*, ext::SpanDiagnosticExt};
+use proc_macro2::TokenStream;
+use syn::{ConstParam, Index, LifetimeParam, Member, TypeParam};
+
+use crate::exports::{*, Status as _Status};
+use crate::http_codegen::Status;
+
+#[derive(Debug, Default, FromMeta)]
+struct ItemAttr {
+    status: Option<SpanWrapped<Status>>,
+    /// Option to generate a respond_to impl with the debug repr of the type
+    debug: bool,
+}
+
+#[derive(Default, FromMeta)]
+struct FieldAttr {
+    source: bool,
+}
+
+pub fn derive_typed_error(input: proc_macro::TokenStream) -> TokenStream {
+    let impl_tokens = quote!(impl<'r> #TypedError<'r>);
+    let typed_error: TokenStream = DeriveGenerator::build_for(input.clone(), impl_tokens)
+        .support(Support::Struct | Support::Enum | Support::Lifetime | Support::Type)
+        .replace_generic(0, 0)
+        .type_bound_mapper(MapperBuild::new()
+            .input_map(|_, i| {
+                let bounds = i.generics().type_params().map(|g| &g.ident);
+                quote! { #(#bounds: ::std::marker::Send + ::std::marker::Sync + 'static,)* }
+            })
+        )
+        .validator(ValidatorBuild::new()
+            .input_validate(|_, i| match i.generics().lifetimes().count() > 1 {
+                true => Err(i.generics().span().error("only one lifetime is supported")),
+                false => Ok(())
+            })
+        )
+        .inner_mapper(MapperBuild::new()
+            .with_output(|_, output| quote! {
+                #[allow(unused_variables)]
+                fn respond_to(&self, request: &'r #Request<'_>)
+                    -> #_Result<#Response<'r>, #_Status>
+                {
+                    #output
+                }
+            })
+            .try_fields_map(|_, fields| {
+                let item = ItemAttr::one_from_attrs("error", fields.parent.attrs())?.unwrap_or(Default::default());
+                let status = item.status.map_or(quote!(#_Status::InternalServerError), |m| quote!(#m));
+                Ok(if item.debug {
+                    quote! {
+                        use #_response::Responder;
+                        #_response::Debug(self)
+                            .respond_to(request)
+                            .map_err(|_| #status)
+                            .map(|mut r| { r.set_status(#status); r })
+                    }
+                } else {
+                    quote! {
+                        #_Err(#status)
+                    }
+                })
+            })
+        )
+        .inner_mapper(MapperBuild::new()
+            .with_output(|_, output| quote! {
+                fn source(&'r self) -> #_Option<&'r (dyn #TypedError<'r> + 'r)> {
+                    #output
+                }
+            })
+            .try_fields_map(|_, fields| {
+                let mut source = None;
+                for field in fields.iter() {
+                    if FieldAttr::one_from_attrs("error", &field.attrs)?.is_some_and(|a| a.source) {
+                        if source.is_some() {
+                            return Err(Diagnostic::spanned(
+                                field.span(),
+                                Level::Error,
+                                "Only one field may be declared as `#[error(source)]`"));
+                        }
+                        if let FieldParent::Variant(_) = field.parent {
+                            let name = field.match_ident();
+                            source = Some(quote! { #_Some(#name as &dyn #TypedError<'r>) })
+                        } else {
+                            let span = field.field.span().into();
+                            let member = match field.ident {
+                                Some(ref ident) => Member::Named(ident.clone()),
+                                None => Member::Unnamed(Index { index: field.index as u32, span })
+                            };
+
+                            source = Some(quote_spanned!(
+                                span => #_Some(&self.#member as &dyn #TypedError<'r>
+                            )));
+                        }
+                    }
+                }
+                Ok(source.unwrap_or_else(|| quote! { #_None }))
+            })
+        )
+        .inner_mapper(MapperBuild::new()
+            .with_output(|_, output| quote! {
+                fn status(&self) -> #_Status { #output }
+            })
+            .try_fields_map(|_, fields| {
+                let item = ItemAttr::one_from_attrs("error", fields.parent.attrs())?.unwrap_or(Default::default());
+                let status = item.status.map_or(quote!(#_Status::InternalServerError), |m| quote!(#m));
+                Ok(quote! { #status })
+            })
+        )
+        .to_tokens();
+    let impl_tokens = quote!(unsafe impl #_catcher::Transient);
+    let transient: TokenStream = DeriveGenerator::build_for(input, impl_tokens)
+        .support(Support::Struct | Support::Enum | Support::Lifetime | Support::Type)
+        .replace_generic(1, 0)
+        .type_bound_mapper(MapperBuild::new()
+            .input_map(|_, i| {
+                let bounds = i.generics().type_params().map(|g| &g.ident);
+                quote! { #(#bounds: 'static,)* }
+            })
+        )
+        .validator(ValidatorBuild::new()
+            .input_validate(|_, i| match i.generics().lifetimes().count() > 1 {
+                true => Err(i.generics().span().error("only one lifetime is supported")),
+                false => Ok(())
+            })
+        )
+        .inner_mapper(MapperBuild::new()
+            .with_output(|_, output| quote! {
+                #output
+            })
+            .input_map(|_, input| {
+                let name = input.ident();
+                let args = input.generics()
+                    .params
+                    .iter()
+                    .map(|g| {
+                        match g {
+                            syn::GenericParam::Lifetime(_) => quote!{ 'static },
+                            syn::GenericParam::Type(TypeParam { ident, .. }) => quote! { #ident },
+                            syn::GenericParam::Const(ConstParam { .. }) => todo!(),
+                        }
+                    });
+                let trans = input.generics()
+                    .lifetimes()
+                    .map(|LifetimeParam { lifetime, .. }| quote!{#_catcher::Inv<#lifetime>});
+                quote!{
+                    type Static = #name <#(#args)*>;
+                    type Transience = (#(#trans,)*);
+                }
+            })
+        )
+        // TODO: hack to generate unsafe impl
+        .outer_mapper(MapperBuild::new()
+            .input_map(|_, _| quote!{ unsafe })
+        )
+        .to_tokens();
+    quote!{
+        #typed_error
+        #transient
+    }
+}

--- a/core/codegen/src/exports.rs
+++ b/core/codegen/src/exports.rs
@@ -102,6 +102,10 @@ define_exported_paths! {
     Route => ::rocket::Route,
     Catcher => ::rocket::Catcher,
     Status => ::rocket::http::Status,
+    TypedError => ::rocket::catcher::TypedError,
+    FromError => ::rocket::catcher::FromError,
+    FromParamError => ::rocket::request::FromParamError,
+    FromSegmentsError => ::rocket::request::FromSegmentsError,
 }
 
 macro_rules! define_spanned_export {

--- a/core/codegen/src/lib.rs
+++ b/core/codegen/src/lib.rs
@@ -1016,6 +1016,13 @@ pub fn derive_responder(input: TokenStream) -> TokenStream {
     emit!(derive::responder::derive_responder(input))
 }
 
+/// Derive for the [`TypedError`] trait.
+// TODO: Typed: Docs
+#[proc_macro_derive(TypedError, attributes(error))]
+pub fn derive_typed_error(input: TokenStream) -> TokenStream {
+    emit!(derive::typed_error::derive_typed_error(input))
+}
+
 /// Derive for the [`UriDisplay<Query>`] trait.
 ///
 /// The [`UriDisplay<Query>`] derive can be applied to enums and structs. When

--- a/core/codegen/src/lib.rs
+++ b/core/codegen/src/lib.rs
@@ -313,6 +313,11 @@ route_attribute!(options => Method::Options);
 /// fn default(status: Status, req: &Request) -> String {
 ///     format!("{} ({})", status, req.uri())
 /// }
+///
+/// #[catch(500, error = "<e>")]
+/// fn std_io_error(e: &std::io::Error) -> String {
+///     format!("Std error: {:?}", e)
+/// }
 /// ```
 ///
 /// # Grammar

--- a/core/codegen/src/lib.rs
+++ b/core/codegen/src/lib.rs
@@ -1035,7 +1035,7 @@ pub fn derive_responder(input: TokenStream) -> TokenStream {
 ///     name: &'r str,
 ///     value: &'r str,
 /// }
-/// 
+///
 /// #[derive(TypedError)]
 /// enum HeaderError {
 ///     InvalidValue,

--- a/core/codegen/tests/catcher.rs
+++ b/core/codegen/tests/catcher.rs
@@ -5,14 +5,20 @@
 
 #[macro_use] extern crate rocket;
 
+use std::io;
+use std::num::ParseIntError;
+use std::str::ParseBoolError;
+
+use rocket::request::FromParamError;
 use rocket::{Request, Rocket, Build};
 use rocket::local::blocking::Client;
 use rocket::http::Status;
+use rocket_http::uri::Origin;
 
 #[catch(404)] fn not_found_0() -> &'static str { "404-0" }
-#[catch(404)] fn not_found_1(_r: &Request<'_>) -> &'static str { "404-1" }
-#[catch(404)] fn not_found_2(_s: Status, _r: &Request<'_>) -> &'static str { "404-2" }
-#[catch(default)] fn all(_s: Status, r: &Request<'_>) -> String { r.uri().to_string() }
+#[catch(404)] fn not_found_1() -> &'static str { "404-1" }
+#[catch(404)] fn not_found_2() -> &'static str { "404-2" }
+#[catch(default)] fn all(r: &Request<'_>) -> String { r.uri().to_string() }
 
 #[test]
 fn test_simple_catchers() {
@@ -37,10 +43,10 @@ fn test_simple_catchers() {
 }
 
 #[get("/<code>")] fn forward(code: u16) -> Status { Status::new(code) }
-#[catch(400)] fn forward_400(status: Status, _r: &Request<'_>) -> String { status.code.to_string() }
-#[catch(404)] fn forward_404(status: Status, _r: &Request<'_>) -> String { status.code.to_string() }
-#[catch(444)] fn forward_444(status: Status, _r: &Request<'_>) -> String { status.code.to_string() }
-#[catch(500)] fn forward_500(status: Status, _r: &Request<'_>) -> String { status.code.to_string() }
+#[catch(400)] fn forward_400(status: Status) -> String { status.code.to_string() }
+#[catch(404)] fn forward_404(status: Status) -> String { status.code.to_string() }
+#[catch(444)] fn forward_444(status: Status) -> String { status.code.to_string() }
+#[catch(500)] fn forward_500(status: Status) -> String { status.code.to_string() }
 
 #[test]
 fn test_status_param() {
@@ -57,4 +63,85 @@ fn test_status_param() {
         assert_eq!(response.status(), Status::new(code));
         assert_eq!(response.into_string().unwrap(), code.to_string());
     }
+}
+
+
+#[catch(400)] fn test_status(status: Status) -> String { format!("{}", status.code) }
+#[catch(404)] fn test_request(r: &Request<'_>) -> String { format!("{}", r.uri()) }
+#[catch(444)] fn test_uri(uri: &Origin<'_>) -> String { format!("{}", uri) }
+
+#[test]
+fn test_basic_params() {
+    fn rocket() -> Rocket<Build> {
+        rocket::build()
+            .mount("/", routes![forward])
+            .register("/", catchers![
+                test_status,
+                test_request,
+                test_uri,
+            ])
+    }
+
+    let client = Client::debug(rocket()).unwrap();
+    let response = client.get(uri!(forward(400))).dispatch();
+    assert_eq!(response.status(), Status::BadRequest);
+    assert_eq!(response.into_string().unwrap(), "400");
+
+    let response = client.get(uri!(forward(404))).dispatch();
+    assert_eq!(response.status(), Status::NotFound);
+    assert_eq!(response.into_string().unwrap(), "/404");
+
+    let response = client.get(uri!(forward(444))).dispatch();
+    assert_eq!(response.status(), Status::new(444));
+    assert_eq!(response.into_string().unwrap(), "/444");
+}
+
+#[get("/c/<code>")] fn read_int(code: u16) -> String { format!("{code}") }
+#[get("/b/<code>")] fn read_bool(code: bool) -> String { format!("{code}") }
+#[get("/b/force")] fn force_bool_error() -> Result<&'static str, ParseBoolError> {
+    "smt".parse::<bool>().map(|_| todo!())
+}
+
+#[catch(default, error = "<e>")]
+fn test_io_error(e: &io::Error) -> String { format!("{e:?}") }
+#[catch(default, error = "<_e>")]
+fn test_parse_int_error(_e: &ParseIntError) -> String { println!("ParseIntError"); format!("ParseIntError") }
+#[catch(default, error = "<_e>")]
+fn test_parse_bool_error(_e: &ParseBoolError) -> String { format!("ParseBoolError") }
+#[catch(default, error = "<e>")]
+fn test_param_parse_bool_error(e: &FromParamError<'_, ParseBoolError>) -> String { format!("ParseBoolError: {}", e.raw) }
+
+
+#[test]
+fn test_error_types() {
+    fn rocket() -> Rocket<Build> {
+        rocket::build()
+            .mount("/", routes![read_int, read_bool, force_bool_error])
+            .register("/", catchers![
+                test_io_error,
+                test_parse_int_error,
+                test_parse_bool_error,
+                test_param_parse_bool_error,
+            ])
+    }
+
+    let client = Client::debug(rocket()).unwrap();
+    let response = client.get(uri!(read_int(400))).dispatch();
+    assert_eq!(response.status(), Status::Ok);
+    assert_eq!(response.into_string().unwrap(), "400");
+
+    let response = client.get(uri!("/c/40000000")).dispatch();
+    assert_eq!(response.status(), Status::UnprocessableEntity);
+    assert_eq!(response.into_string().unwrap(), "ParseIntError");
+
+    let response = client.get(uri!(read_bool(true))).dispatch();
+    assert_eq!(response.status(), Status::Ok);
+    assert_eq!(response.into_string().unwrap(), "true");
+
+    let response = client.get(uri!("/b/smt")).dispatch();
+    assert_eq!(response.status(), Status::UnprocessableEntity);
+    assert_eq!(response.into_string().unwrap(), "ParseBoolError: smt");
+    let response = client.get(uri!("/b/force")).dispatch();
+    assert_eq!(response.status(), Status::BadRequest);
+    assert_eq!(response.into_string().unwrap(), "ParseBoolError");
 }

--- a/core/codegen/tests/catcher.rs
+++ b/core/codegen/tests/catcher.rs
@@ -10,9 +10,9 @@ use rocket::local::blocking::Client;
 use rocket::http::Status;
 
 #[catch(404)] fn not_found_0() -> &'static str { "404-0" }
-#[catch(404)] fn not_found_1(_: &Request<'_>) -> &'static str { "404-1" }
-#[catch(404)] fn not_found_2(_: Status, _: &Request<'_>) -> &'static str { "404-2" }
-#[catch(default)] fn all(_: Status, r: &Request<'_>) -> String { r.uri().to_string() }
+#[catch(404)] fn not_found_1(_r: &Request<'_>) -> &'static str { "404-1" }
+#[catch(404)] fn not_found_2(_s: Status, _r: &Request<'_>) -> &'static str { "404-2" }
+#[catch(default)] fn all(_s: Status, r: &Request<'_>) -> String { r.uri().to_string() }
 
 #[test]
 fn test_simple_catchers() {
@@ -37,10 +37,10 @@ fn test_simple_catchers() {
 }
 
 #[get("/<code>")] fn forward(code: u16) -> Status { Status::new(code) }
-#[catch(400)] fn forward_400(status: Status, _: &Request<'_>) -> String { status.code.to_string() }
-#[catch(404)] fn forward_404(status: Status, _: &Request<'_>) -> String { status.code.to_string() }
-#[catch(444)] fn forward_444(status: Status, _: &Request<'_>) -> String { status.code.to_string() }
-#[catch(500)] fn forward_500(status: Status, _: &Request<'_>) -> String { status.code.to_string() }
+#[catch(400)] fn forward_400(status: Status, _r: &Request<'_>) -> String { status.code.to_string() }
+#[catch(404)] fn forward_404(status: Status, _r: &Request<'_>) -> String { status.code.to_string() }
+#[catch(444)] fn forward_444(status: Status, _r: &Request<'_>) -> String { status.code.to_string() }
+#[catch(500)] fn forward_500(status: Status, _r: &Request<'_>) -> String { status.code.to_string() }
 
 #[test]
 fn test_status_param() {

--- a/core/codegen/tests/catcher.rs
+++ b/core/codegen/tests/catcher.rs
@@ -105,11 +105,13 @@ fn test_basic_params() {
 #[catch(default, error = "<e>")]
 fn test_io_error(e: &io::Error) -> String { format!("{e:?}") }
 #[catch(default, error = "<_e>")]
-fn test_parse_int_error(_e: &ParseIntError) -> String { println!("ParseIntError"); format!("ParseIntError") }
+fn test_parse_int_error(_e: &ParseIntError) -> String { format!("ParseIntError") }
 #[catch(default, error = "<_e>")]
 fn test_parse_bool_error(_e: &ParseBoolError) -> String { format!("ParseBoolError") }
 #[catch(default, error = "<e>")]
-fn test_param_parse_bool_error(e: &FromParamError<'_, ParseBoolError>) -> String { format!("ParseBoolError: {}", e.raw) }
+fn test_param_parse_bool_error(e: &FromParamError<'_, ParseBoolError>) -> String {
+    format!("ParseBoolError: {}", e.raw)
+}
 
 
 #[test]

--- a/core/codegen/tests/route-data.rs
+++ b/core/codegen/tests/route-data.rs
@@ -1,5 +1,6 @@
 #[macro_use] extern crate rocket;
 
+use rocket::response::status::BadRequest;
 use rocket::{Request, Data};
 use rocket::local::blocking::Client;
 use rocket::data::{self, FromData};
@@ -17,7 +18,7 @@ struct Simple<'r>(&'r str);
 
 #[async_trait]
 impl<'r> FromData<'r> for Simple<'r> {
-    type Error = std::io::Error;
+    type Error = BadRequest<std::io::Error>;
 
     async fn from_data(req: &'r Request<'_>, data: Data<'r>) -> data::Outcome<'r, Self> {
         <&'r str>::from_data(req, data).await.map(Simple)

--- a/core/codegen/tests/route.rs
+++ b/core/codegen/tests/route.rs
@@ -12,6 +12,7 @@ use rocket::http::ext::Normalize;
 use rocket::local::blocking::Client;
 use rocket::data::{self, Data, FromData};
 use rocket::http::{Status, RawStr, ContentType, uri::fmt::Path};
+use rocket::response::status::BadRequest;
 
 // Use all of the code generation available at once.
 
@@ -24,7 +25,7 @@ struct Simple(String);
 
 #[async_trait]
 impl<'r> FromData<'r> for Simple {
-    type Error = std::io::Error;
+    type Error = BadRequest<std::io::Error>;
 
     async fn from_data(req: &'r Request<'_>, data: Data<'r>) -> data::Outcome<'r, Self> {
         String::from_data(req, data).await.map(Simple)

--- a/core/codegen/tests/typed_error.rs
+++ b/core/codegen/tests/typed_error.rs
@@ -1,0 +1,69 @@
+#[macro_use] extern crate rocket;
+use rocket::catcher::TypedError;
+use rocket::http::Status;
+
+fn boxed_error<'r>(_val: Box<dyn TypedError<'r> + 'r>) {}
+
+#[derive(TypedError)]
+pub enum Foo<'r> {
+    First(String),
+    Second(Vec<u8>),
+    Third {
+        #[error(source)]
+        responder: std::io::Error,
+    },
+    #[error(status = 400)]
+    Fourth {
+        string: &'r str,
+    },
+}
+
+#[test]
+fn validate_foo() {
+    let first = Foo::First("".into());
+    assert_eq!(first.status(), Status::InternalServerError);
+    assert!(first.source(0).is_none());
+    boxed_error(Box::new(first));
+    let second = Foo::Second(vec![]);
+    assert_eq!(second.status(), Status::InternalServerError);
+    assert!(second.source(0).is_none());
+    boxed_error(Box::new(second));
+    let third = Foo::Third {
+        responder: std::io::Error::new(std::io::ErrorKind::NotFound, ""),
+    };
+    assert_eq!(third.status(), Status::InternalServerError);
+    assert!(std::ptr::eq(
+        third.source(0).unwrap(),
+        if let Foo::Third { responder } = &third { responder } else { panic!() }
+    ));
+    boxed_error(Box::new(third));
+    let fourth = Foo::Fourth { string: "" };
+    assert_eq!(fourth.status(), Status::BadRequest);
+    assert!(fourth.source(0).is_none());
+    boxed_error(Box::new(fourth));
+}
+
+#[derive(TypedError)]
+pub struct InfallibleError {
+    #[error(source)]
+    _inner: std::convert::Infallible,
+}
+
+#[derive(TypedError)]
+pub struct StaticError {
+    #[error(source)]
+    inner: std::string::FromUtf8Error,
+}
+
+#[test]
+fn validate_static() {
+    let val = StaticError {
+        inner: String::from_utf8(vec![0xFF]).unwrap_err(),
+    };
+    assert_eq!(val.status(), Status::InternalServerError);
+    assert!(std::ptr::eq(
+        val.source(0).unwrap(),
+        &val.inner,
+    ));
+    boxed_error(Box::new(val));
+}

--- a/core/codegen/tests/typed_error.rs
+++ b/core/codegen/tests/typed_error.rs
@@ -78,3 +78,18 @@ pub struct GenericWithLifetime<'r, E> {
     s: &'r str,
     inner: E,
 }
+
+#[derive(TypedError)]
+#[error(status = 404)]
+enum EnumStatusOverride {
+  #[error(status = 400)]
+  BadRequest,
+  NotFound,
+}
+
+#[test]
+fn validate_enum_status_override() {
+    assert_eq!(EnumStatusOverride::BadRequest.status(), Status::BadRequest);
+    assert_eq!(EnumStatusOverride::NotFound.status(), Status::NotFound);
+    boxed_error(Box::new(EnumStatusOverride::BadRequest));
+}

--- a/core/codegen/tests/typed_error.rs
+++ b/core/codegen/tests/typed_error.rs
@@ -67,3 +67,14 @@ fn validate_static() {
     ));
     boxed_error(Box::new(val));
 }
+
+#[derive(TypedError)]
+pub enum Generic<E> {
+    First(E),
+}
+
+#[derive(TypedError)]
+pub struct GenericWithLifetime<'r, E> {
+    s: &'r str,
+    inner: E,
+}

--- a/core/http/Cargo.toml
+++ b/core/http/Cargo.toml
@@ -36,7 +36,8 @@ memchr = "2"
 stable-pattern = "0.1"
 cookie = { version = "0.18", features = ["percent-encode"] }
 state = "0.6"
-transient = "0.4.1"
+# transient = "0.4.1"
+transient = { git = "https://github.com/the10thWiz/transient.git", branch = "rocket-ready" }
 
 [dependencies.serde]
 version = "1.0"

--- a/core/http/Cargo.toml
+++ b/core/http/Cargo.toml
@@ -21,7 +21,7 @@ workspace = true
 [features]
 default = []
 serde = ["dep:serde", "uncased/with-serde-alloc"]
-uuid = ["dep:uuid"]
+uuid = ["dep:uuid", "transient/uuid"]
 
 [dependencies]
 tinyvec = { version = "1.6", features = ["std", "rustc_1_57"] }
@@ -36,6 +36,7 @@ memchr = "2"
 stable-pattern = "0.1"
 cookie = { version = "0.18", features = ["percent-encode"] }
 state = "0.6"
+transient = "0.4.1"
 
 [dependencies.serde]
 version = "1.0"

--- a/core/http/src/lib.rs
+++ b/core/http/src/lib.rs
@@ -36,7 +36,7 @@ pub mod private {
 }
 
 pub use crate::method::Method;
-pub use crate::status::{Status, StatusClass};
+pub use crate::status::{Status, StatusClass, AsStatus};
 pub use crate::raw_str::{RawStr, RawStrBuf};
 pub use crate::header::*;
 

--- a/core/http/src/lib.rs
+++ b/core/http/src/lib.rs
@@ -36,7 +36,7 @@ pub mod private {
 }
 
 pub use crate::method::Method;
-pub use crate::status::{Status, StatusClass, AsStatus};
+pub use crate::status::{Status, StatusClass};
 pub use crate::raw_str::{RawStr, RawStrBuf};
 pub use crate::header::*;
 

--- a/core/http/src/status.rs
+++ b/core/http/src/status.rs
@@ -43,6 +43,14 @@ impl StatusClass {
     class_check_fn!(is_unknown, "`Unknown`.", Unknown);
 }
 
+/// Trait to convert any type into a status
+///
+/// Mostly used to allow `Status` to implement `From<T>` for any type `T`.
+pub trait AsStatus {
+    /// Status associated with this particular object
+    fn as_status(&self) -> Status;
+}
+
 /// Structure representing an HTTP status: an integer code.
 ///
 /// A `Status` should rarely be created directly. Instead, an associated
@@ -124,6 +132,12 @@ impl Static for Status {}
 impl Default for Status {
     fn default() -> Self {
         Status::Ok
+    }
+}
+
+impl<T: AsStatus> From<T> for Status {
+    fn from(val: T) -> Self {
+        val.as_status()
     }
 }
 

--- a/core/http/src/status.rs
+++ b/core/http/src/status.rs
@@ -1,4 +1,5 @@
 use std::fmt;
+use transient::Static;
 
 /// Enumeration of HTTP status classes.
 #[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]
@@ -117,6 +118,8 @@ pub struct Status {
     /// The HTTP status code associated with this status.
     pub code: u16,
 }
+
+impl Static for Status {}
 
 impl Default for Status {
     fn default() -> Self {

--- a/core/http/src/status.rs
+++ b/core/http/src/status.rs
@@ -43,14 +43,6 @@ impl StatusClass {
     class_check_fn!(is_unknown, "`Unknown`.", Unknown);
 }
 
-/// Trait to convert any type into a status
-///
-/// Mostly used to allow `Status` to implement `From<T>` for any type `T`.
-pub trait AsStatus {
-    /// Status associated with this particular object
-    fn as_status(&self) -> Status;
-}
-
 /// Structure representing an HTTP status: an integer code.
 ///
 /// A `Status` should rarely be created directly. Instead, an associated
@@ -132,12 +124,6 @@ impl Static for Status {}
 impl Default for Status {
     fn default() -> Self {
         Status::Ok
-    }
-}
-
-impl<T: AsStatus> From<T> for Status {
-    fn from(val: T) -> Self {
-        val.as_status()
     }
 }
 

--- a/core/http/src/uri/error.rs
+++ b/core/http/src/uri/error.rs
@@ -2,6 +2,8 @@
 
 use std::fmt;
 
+use transient::Static;
+
 pub use crate::parse::uri::Error;
 
 /// The error type returned when a URI conversion fails.
@@ -28,6 +30,8 @@ pub enum PathError {
     /// The segment ended with the wrapped invalid character.
     BadEnd(char),
 }
+
+impl Static for PathError {}
 
 impl fmt::Display for PathError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/core/http/src/uri/fmt/uri_display.rs
+++ b/core/http/src/uri/fmt/uri_display.rs
@@ -243,13 +243,13 @@ use crate::uri::fmt::{Part, Path, Query, Formatter};
 /// const PREFIX: &str = "name:";
 ///
 /// impl<'r> FromParam<'r> for Name<'r> {
-///     type Error = &'r str;
+///     type Error = ();
 ///
 ///     /// Validates parameters that start with 'name:', extracting the text
 ///     /// after 'name:' as long as there is at least one character.
 ///     fn from_param(param: &'r str) -> Result<Self, Self::Error> {
 ///         if !param.starts_with(PREFIX) || param.len() < (PREFIX.len() + 1) {
-///             return Err(param);
+///             return Err(());
 ///         }
 ///
 ///         let real_name = &param[PREFIX.len()..];

--- a/core/lib/Cargo.toml
+++ b/core/lib/Cargo.toml
@@ -74,7 +74,8 @@ tokio-stream = { version = "0.1.6", features = ["signal", "time"] }
 cookie = { version = "0.18", features = ["percent-encode"] }
 futures = { version = "0.3.30", default-features = false, features = ["std"] }
 state = "0.6"
-transient = { version = "0.4.1", features = ["either"] }
+# transient = { version = "0.4.1", features = ["either"] }
+transient = { features = ["either"], git = "https://github.com/the10thWiz/transient.git", branch = "rocket-ready" }
 
 # tracing
 tracing = { version = "0.1.40", default-features = false, features = ["std", "attributes"] }

--- a/core/lib/Cargo.toml
+++ b/core/lib/Cargo.toml
@@ -27,9 +27,9 @@ default = ["http2", "tokio-macros", "trace"]
 http2 = ["hyper/http2", "hyper-util/http2"]
 http3-preview = ["s2n-quic", "s2n-quic-h3", "tls"]
 secrets = ["cookie/private", "cookie/key-expansion"]
-json = ["serde_json"]
-msgpack = ["rmp-serde"]
-uuid = ["uuid_", "rocket_http/uuid"]
+json = ["serde_json", "transient/serde_json"]
+msgpack = ["rmp-serde", "transient/rmp-serde"]
+uuid = ["uuid_", "rocket_http/uuid", "transient/uuid"]
 tls = ["rustls", "tokio-rustls", "rustls-pemfile"]
 mtls = ["tls", "x509-parser"]
 tokio-macros = ["tokio/macros"]
@@ -74,6 +74,7 @@ tokio-stream = { version = "0.1.6", features = ["signal", "time"] }
 cookie = { version = "0.18", features = ["percent-encode"] }
 futures = { version = "0.3.30", default-features = false, features = ["std"] }
 state = "0.6"
+transient = { version = "0.4.1", features = ["either"] }
 
 # tracing
 tracing = { version = "0.1.40", default-features = false, features = ["std", "attributes"] }

--- a/core/lib/src/catcher/catcher.rs
+++ b/core/lib/src/catcher/catcher.rs
@@ -154,22 +154,34 @@ impl Catcher {
     ///
     /// ```rust
     /// use rocket::request::Request;
-    /// use rocket::catcher::{Catcher, BoxFuture};
+    /// use rocket::catcher::{Catcher, BoxFuture, TypedError};
     /// use rocket::response::Responder;
     /// use rocket::http::Status;
     ///
-    /// fn handle_404<'r>(status: Status, req: &'r Request<'_>) -> BoxFuture<'r> {
-    ///    let res = (status, format!("404: {}", req.uri()));
-    ///    Box::pin(async move { res.respond_to(req) })
+    /// fn handle_404<'r>(
+    ///     status: Status,
+    ///     _: &'r dyn TypedError<'r>,
+    ///     req: &'r Request<'_>
+    /// ) -> BoxFuture<'r> {
+    ///     let res = (status, format!("404: {}", req.uri()));
+    ///     Box::pin(async move { res.respond_to(req).map_err(|e| e.into()) })
     /// }
     ///
-    /// fn handle_500<'r>(_: Status, req: &'r Request<'_>) -> BoxFuture<'r> {
-    ///     Box::pin(async move{ "Whoops, we messed up!".respond_to(req) })
+    /// fn handle_500<'r>(
+    ///     status: Status,
+    ///     _: &'r dyn TypedError<'r>,
+    ///     req: &'r Request<'_>
+    /// ) -> BoxFuture<'r> {
+    ///     Box::pin(async move{ "Whoops, we messed up!".respond_to(req).map_err(|e| e.into()) })
     /// }
     ///
-    /// fn handle_default<'r>(status: Status, req: &'r Request<'_>) -> BoxFuture<'r> {
+    /// fn handle_default<'r>(
+    ///     status: Status,
+    ///     _: &'r dyn TypedError<'r>,
+    ///     req: &'r Request<'_>
+    /// ) -> BoxFuture<'r> {
     ///    let res = (status, format!("{}: {}", status, req.uri()));
-    ///    Box::pin(async move { res.respond_to(req) })
+    ///    Box::pin(async move { res.respond_to(req).map_err(|e| e.into()) })
     /// }
     ///
     /// let not_found_catcher = Catcher::new(404, handle_404);
@@ -207,13 +219,17 @@ impl Catcher {
     ///
     /// ```rust
     /// use rocket::request::Request;
-    /// use rocket::catcher::{Catcher, BoxFuture};
+    /// use rocket::catcher::{Catcher, BoxFuture, TypedError};
     /// use rocket::response::Responder;
     /// use rocket::http::Status;
     ///
-    /// fn handle_404<'r>(status: Status, req: &'r Request<'_>) -> BoxFuture<'r> {
+    /// fn handle_404<'r>(
+    ///    status: Status,
+    ///    _e: &'r dyn TypedError<'r>,
+    ///    req: &'r Request<'_>
+    /// ) -> BoxFuture<'r> {
     ///    let res = (status, format!("404: {}", req.uri()));
-    ///    Box::pin(async move { res.respond_to(req) })
+    ///    Box::pin(async move { res.respond_to(req).map_err(|e| e.into()) })
     /// }
     ///
     /// let catcher = Catcher::new(404, handle_404);
@@ -233,14 +249,18 @@ impl Catcher {
     ///
     /// ```rust
     /// use rocket::request::Request;
-    /// use rocket::catcher::{Catcher, BoxFuture};
+    /// use rocket::catcher::{Catcher, BoxFuture, TypedError};
     /// use rocket::response::Responder;
     /// use rocket::http::Status;
     /// # use rocket::uri;
     ///
-    /// fn handle_404<'r>(status: Status, req: &'r Request<'_>) -> BoxFuture<'r> {
+    /// fn handle_404<'r>(
+    ///    status: Status,
+    ///    _e: &'r dyn TypedError<'r>,
+    ///    req: &'r Request<'_>
+    /// ) -> BoxFuture<'r> {
     ///    let res = (status, format!("404: {}", req.uri()));
-    ///    Box::pin(async move { res.respond_to(req) })
+    ///    Box::pin(async move { res.respond_to(req).map_err(|e| e.into()) })
     /// }
     ///
     /// let catcher = Catcher::new(404, handle_404);
@@ -287,13 +307,17 @@ impl Catcher {
     ///
     /// ```rust
     /// use rocket::request::Request;
-    /// use rocket::catcher::{Catcher, BoxFuture};
+    /// use rocket::catcher::{Catcher, BoxFuture, TypedError};
     /// use rocket::response::Responder;
     /// use rocket::http::Status;
     ///
-    /// fn handle_404<'r>(status: Status, req: &'r Request<'_>) -> BoxFuture<'r> {
+    /// fn handle_404<'r>(
+    ///     status: Status,
+    ///     _: &'r dyn TypedError<'r>,
+    ///     req: &'r Request<'_>
+    /// ) -> BoxFuture<'r> {
     ///    let res = (status, format!("404: {}", req.uri()));
-    ///    Box::pin(async move { res.respond_to(req) })
+    ///    Box::pin(async move { res.respond_to(req).map_err(|e| e.into()) })
     /// }
     ///
     /// let catcher = Catcher::new(404, handle_404);
@@ -321,7 +345,11 @@ impl Catcher {
 
 impl Default for Catcher {
     fn default() -> Self {
-        fn handler<'r>(status: Status, e: &'r dyn TypedError<'r>, req: &'r Request<'_>) -> BoxFuture<'r> {
+        fn handler<'r>(
+            status: Status,
+            e: &'r dyn TypedError<'r>,
+            req: &'r Request<'_>
+        ) -> BoxFuture<'r> {
             Box::pin(async move { Ok(default_handler(status, e, req)) })
         }
 

--- a/core/lib/src/catcher/catcher.rs
+++ b/core/lib/src/catcher/catcher.rs
@@ -133,7 +133,7 @@ pub struct Catcher {
     pub(crate) rank: isize,
 
     /// TypeId to match against
-    type_info: Option<(&'static str, TypeId)>,
+    pub(crate) type_info: Option<(&'static str, TypeId)>,
 
     /// The catcher's file, line, and column location.
     pub(crate) location: Option<(&'static str, u32, u32)>,

--- a/core/lib/src/catcher/from_error.rs
+++ b/core/lib/src/catcher/from_error.rs
@@ -68,9 +68,9 @@ impl<'r, T: FromRequest<'r>> FromError<'r> for T {
                 info!("Catcher guard error type: `{:?}`", e.name());
                 Err(e.status())
             },
-            Outcome::Forward(s) => {
-                info!(status = %s, "Catcher guard forwarding");
-                Err(s)
+            Outcome::Forward(e) => {
+                info!("Catcher guard error type: `{:?}`", e.name());
+                Err(e.status())
             },
         }
     }

--- a/core/lib/src/catcher/from_error.rs
+++ b/core/lib/src/catcher/from_error.rs
@@ -1,0 +1,88 @@
+use async_trait::async_trait;
+
+use crate::http::Status;
+use crate::outcome::Outcome;
+use crate::request::FromRequest;
+use crate::Request;
+
+use crate::catcher::TypedError;
+
+/// Trait used to extract types for an error catcher. You should
+/// pretty much never implement this yourself. There are several
+/// existing implementations, that should cover every need.
+///
+/// - [`Status`]: Extracts the HTTP status that this error is catching.
+/// - [`&Request<'_>`]: Extracts a reference to the entire request that
+///     triggered this error to begin with.
+/// - [`T: FromRequest<'_>`]: Extracts type that implements `FromRequest`
+/// - [`&dyn TypedError<'_>`]: Extracts the typed error, as a dynamic
+///     trait object.
+/// - [`Option<&dyn TypedError<'_>>`]: Same as previous, but succeeds even
+///     if there is no typed error to extract.
+///
+/// [`Status`]: crate::http::Status
+/// [`&Request<'_>`]: crate::request::Request
+/// [`&dyn TypedError<'_>`]: crate::catcher::TypedError
+/// [`Option<&dyn TypedError<'_>>`]: crate::catcher::TypedError
+#[async_trait]
+pub trait FromError<'r>: Sized {
+    async fn from_error(
+        status: Status,
+        request: &'r Request<'r>,
+        error: &'r dyn TypedError<'r>
+    ) -> Result<Self, Status>;
+}
+
+#[async_trait]
+impl<'r> FromError<'r> for Status {
+    async fn from_error(
+        status: Status,
+        _r: &'r Request<'r>,
+        _e: &'r dyn TypedError<'r>
+    ) -> Result<Self, Status> {
+        Ok(status)
+    }
+}
+
+#[async_trait]
+impl<'r> FromError<'r> for &'r Request<'r> {
+    async fn from_error(
+        _s: Status,
+        req: &'r Request<'r>,
+        _e: &'r dyn TypedError<'r>
+    ) -> Result<Self, Status> {
+        Ok(req)
+    }
+}
+
+#[async_trait]
+impl<'r, T: FromRequest<'r>> FromError<'r> for T {
+    async fn from_error(
+        _s: Status,
+        req: &'r Request<'r>,
+        _e: &'r dyn TypedError<'r>
+    ) -> Result<Self, Status> {
+        match T::from_request(req).await {
+            Outcome::Success(val) => Ok(val),
+            Outcome::Error(e) => {
+                info!("Catcher guard error type: `{:?}`", e.name());
+                Err(e.status())
+            },
+            Outcome::Forward(s) => {
+                info!(status = %s, "Catcher guard forwarding");
+                Err(s)
+            },
+        }
+    }
+}
+
+#[async_trait]
+impl<'r> FromError<'r> for &'r dyn TypedError<'r> {
+    async fn from_error(
+        _s: Status,
+        _r: &'r Request<'r>,
+        error: &'r dyn TypedError<'r>
+    ) -> Result<Self, Status> {
+        Ok(error)
+    }
+}

--- a/core/lib/src/catcher/handler.rs
+++ b/core/lib/src/catcher/handler.rs
@@ -32,6 +32,7 @@ pub type BoxFuture<'r, T = Result<'r>> = futures::future::BoxFuture<'r, T>;
 /// use rocket::{Request, Catcher, catcher};
 /// use rocket::response::{Response, Responder};
 /// use rocket::http::Status;
+/// use rocket::catcher::TypedError;
 ///
 /// #[derive(Copy, Clone)]
 /// enum Kind {
@@ -45,7 +46,7 @@ pub type BoxFuture<'r, T = Result<'r>> = futures::future::BoxFuture<'r, T>;
 ///
 /// #[rocket::async_trait]
 /// impl catcher::Handler for CustomHandler {
-///     async fn handle<'r>(&self, status: Status, req: &'r Request<'_>) -> catcher::Result<'r> {
+///     async fn handle<'r>(&self, status: Status, _e: &'r dyn TypedError<'r>, req: &'r Request<'_>) -> catcher::Result<'r> {
 ///         let inner = match self.0 {
 ///             Kind::Simple => "simple".respond_to(req)?,
 ///             Kind::Intermediate => "intermediate".respond_to(req)?,
@@ -98,7 +99,12 @@ pub trait Handler: Cloneable + Send + Sync + 'static {
     /// Nevertheless, failure is allowed, both for convenience and necessity. If
     /// an error handler fails, Rocket's default `500` catcher is invoked. If it
     /// succeeds, the returned `Response` is used to respond to the client.
-    async fn handle<'r>(&self, status: Status, error: &'r dyn TypedError<'r>, req: &'r Request<'_>) -> Result<'r>;
+    async fn handle<'r>(
+        &self,
+        status: Status,
+        error: &'r dyn TypedError<'r>,
+        req: &'r Request<'_>
+    ) -> Result<'r>;
 }
 
 // We write this manually to avoid double-boxing.
@@ -122,7 +128,11 @@ impl<F: Clone + Sync + Send + 'static> Handler for F
 
 // Used in tests! Do not use, please.
 #[doc(hidden)]
-pub fn dummy_handler<'r>(_: Status, _: &'r dyn TypedError<'r>, _: &'r Request<'_>) -> BoxFuture<'r> {
+pub fn dummy_handler<'r>(
+    _: Status,
+    _: &'r dyn TypedError<'r>,
+    _: &'r Request<'_>
+) -> BoxFuture<'r> {
    Box::pin(async move { Ok(Response::new()) })
 }
 

--- a/core/lib/src/catcher/handler.rs
+++ b/core/lib/src/catcher/handler.rs
@@ -89,7 +89,6 @@ pub type BoxFuture<'r, T = Result<'r>> = futures::future::BoxFuture<'r, T>;
 ///      directly as the parameter to `rocket.register("/", )`.
 ///   3. Unlike static-function-based handlers, this custom handler can make use
 ///      of internal state.
-// TODO: Typed: Docs
 #[crate::async_trait]
 pub trait Handler: Cloneable + Send + Sync + 'static {
     /// Called by Rocket when an error with `status` for a given `Request`

--- a/core/lib/src/catcher/handler.rs
+++ b/core/lib/src/catcher/handler.rs
@@ -88,6 +88,7 @@ pub type BoxFuture<'r, T = Result<'r>> = futures::future::BoxFuture<'r, T>;
 ///      directly as the parameter to `rocket.register("/", )`.
 ///   3. Unlike static-function-based handlers, this custom handler can make use
 ///      of internal state.
+// TODO: Typed: Docs
 #[crate::async_trait]
 pub trait Handler: Cloneable + Send + Sync + 'static {
     /// Called by Rocket when an error with `status` for a given `Request`

--- a/core/lib/src/catcher/mod.rs
+++ b/core/lib/src/catcher/mod.rs
@@ -3,7 +3,9 @@
 mod catcher;
 mod handler;
 mod types;
+mod from_error;
 
 pub use catcher::*;
 pub use handler::*;
 pub use types::*;
+pub use from_error::*;

--- a/core/lib/src/catcher/mod.rs
+++ b/core/lib/src/catcher/mod.rs
@@ -2,6 +2,8 @@
 
 mod catcher;
 mod handler;
+mod types;
 
 pub use catcher::*;
 pub use handler::*;
+pub use types::*;

--- a/core/lib/src/catcher/types.rs
+++ b/core/lib/src/catcher/types.rs
@@ -77,6 +77,12 @@ impl<'r> TypedError<'r> for Status {
     }
 }
 
+impl<'r> From<Status> for Box<dyn TypedError<'r> + 'r> {
+    fn from(value: Status) -> Self {
+        Box::new(value)
+    }
+}
+
 // TODO: Typed: update transient to make the possible.
 // impl<'r, R: TypedError<'r> + Transient> TypedError<'r> for (Status, R)
 //     where R::Transience: CanTranscendTo<Inv<'r>>

--- a/core/lib/src/catcher/types.rs
+++ b/core/lib/src/catcher/types.rs
@@ -2,7 +2,7 @@ use std::fmt;
 
 use either::Either;
 use transient::{Any, CanRecoverFrom, Downcast, Transience};
-use crate::{http::{Status, AsStatus}, response::status::Custom, Request, Response};
+use crate::{http::Status, response::status::Custom, Request, Response};
 #[doc(inline)]
 pub use transient::{Static, Transient, TypeId, Inv, CanTranscendTo};
 
@@ -40,6 +40,9 @@ pub trait TypedError<'r>: AsAny<Inv<'r>> + Send + Sync + 'r {
     /// Generates a default response for this type (or forwards to a default catcher)
     #[allow(unused_variables)]
     fn respond_to(&self, request: &'r Request<'_>) -> Result<Response<'r>, Status> {
+        Err(self.status())
+    }
+    fn respond_to2(self: Box<Self>, request: &'r Request<'_>) -> Result<Response<'r>, Status> {
         Err(self.status())
     }
 
@@ -83,9 +86,9 @@ impl<'r> From<Status> for Box<dyn TypedError<'r> + 'r> {
     }
 }
 
-impl AsStatus for Box<dyn TypedError<'_> + '_> {
-    fn as_status(&self) -> Status {
-        self.status()
+impl From<Box<dyn TypedError<'_> + '_>> for Status {
+    fn from(value: Box<dyn TypedError<'_> + '_>) -> Self {
+        value.status()
     }
 }
 

--- a/core/lib/src/catcher/types.rs
+++ b/core/lib/src/catcher/types.rs
@@ -42,9 +42,6 @@ pub trait TypedError<'r>: AsAny<Inv<'r>> + Send + Sync + 'r {
     fn respond_to(&self, request: &'r Request<'_>) -> Result<Response<'r>, Status> {
         Err(self.status())
     }
-    fn respond_to2(self: Box<Self>, request: &'r Request<'_>) -> Result<Response<'r>, Status> {
-        Err(self.status())
-    }
 
     /// A descriptive name of this error type. Defaults to the type name.
     fn name(&self) -> &'static str { std::any::type_name::<Self>() }

--- a/core/lib/src/catcher/types.rs
+++ b/core/lib/src/catcher/types.rs
@@ -150,6 +150,10 @@ impl<'r> TypedError<'r> for std::string::FromUtf8Error {
     fn status(&self) -> Status { Status::BadRequest }
 }
 
+impl<'r> TypedError<'r> for crate::http::uri::error::PathError {
+    fn status(&self) -> Status { Status::BadRequest }
+}
+
 #[cfg(feature = "json")]
 impl<'r> TypedError<'r> for serde_json::Error {
     fn status(&self) -> Status { Status::BadRequest }

--- a/core/lib/src/catcher/types.rs
+++ b/core/lib/src/catcher/types.rs
@@ -1,0 +1,334 @@
+use either::Either;
+use transient::{Any, CanRecoverFrom, Downcast, Transience};
+use crate::{http::Status, response::status::Custom, Request, Response};
+#[doc(inline)]
+pub use transient::{Static, Transient, TypeId, Inv, CanTranscendTo};
+
+/// Polyfill for trait upcasting to [`Any`]
+pub trait AsAny<Tr: Transience>: Any<Tr> + Sealed<Tr> {
+    /// The actual upcast
+    fn as_any(&self) -> &dyn Any<Tr>;
+    /// convience typeid of the inner typeid
+    fn trait_obj_typeid(&self) -> TypeId;
+}
+
+use sealed::Sealed;
+mod sealed {
+    use transient::{Any, Transience, Transient, TypeId};
+
+    use super::AsAny;
+
+    pub trait Sealed<Tr> {}
+    impl<'r, Tr: Transience, T: Any<Tr>> Sealed<Tr> for T { }
+    impl<'r, Tr: Transience, T: Any<Tr> + Transient> AsAny<Tr> for T {
+        fn as_any(&self) -> &dyn Any<Tr> {
+            self
+        }
+        fn trait_obj_typeid(&self) -> transient::TypeId {
+            TypeId::of::<T>()
+        }
+    }
+}
+
+/// This is the core of typed catchers. If an error type (returned by
+/// FromParam, FromRequest, FromForm, FromData, or Responder) implements
+/// this trait, it can be caught by a typed catcher. (TODO) This trait
+/// can be derived.
+pub trait TypedError<'r>: AsAny<Inv<'r>> + Send + Sync + 'r {
+    /// Generates a default response for this type (or forwards to a default catcher)
+    #[allow(unused_variables)]
+    fn respond_to(&self, request: &'r Request<'_>) -> Result<Response<'r>, Status> {
+        Err(self.status())
+    }
+
+    /// A descriptive name of this error type. Defaults to the type name.
+    fn name(&self) -> &'static str { std::any::type_name::<Self>() }
+
+    /// The error that caused this error. Defaults to None.
+    ///
+    /// # Warning
+    /// A typed catcher will not attempt to follow the source of an error
+    /// more than (TODO: exact number) 5 times.
+    fn source(&'r self) -> Option<&'r (dyn TypedError<'r> + 'r)> { None }
+
+    /// Status code
+    fn status(&self) -> Status { Status::InternalServerError }
+}
+
+// TODO: this is less useful, since impls should generally use `Status` instead.
+impl<'r> TypedError<'r> for () {  }
+
+impl<'r> TypedError<'r> for Status {
+    fn respond_to(&self, _r: &'r Request<'_>) -> Result<Response<'r>, Status> {
+        Err(*self)
+    }
+
+    fn name(&self) -> &'static str {
+        // TODO: Status generally shouldn't be caught
+        "<Status>"
+    }
+
+    fn source(&'r self) -> Option<&'r (dyn TypedError<'r> + 'r)> {
+        Some(&())
+    }
+
+    fn status(&self) -> Status {
+        *self
+    }
+}
+
+// TODO: Typed: update transient to make the possible.
+// impl<'r, R: TypedError<'r> + Transient> TypedError<'r> for (Status, R)
+//     where R::Transience: CanTranscendTo<Inv<'r>>
+// {
+//     fn respond_to(&self, request: &'r Request<'_>) -> Result<Response<'r>, Status> {
+//         self.1.respond_to(request)
+//     }
+
+//     fn name(&self) -> &'static str {
+//         self.1.name()
+//     }
+
+//     fn source(&'r self) -> Option<&'r (dyn TypedError<'r> + 'r)> {
+//         Some(&self.1)
+//     }
+
+//     fn status(&self) -> Status {
+//         self.0
+//     }
+// }
+
+impl<'r, R: TypedError<'r> + Transient> TypedError<'r> for Custom<R>
+    where R::Transience: CanTranscendTo<Inv<'r>>
+{
+    fn respond_to(&self, request: &'r Request<'_>) -> Result<Response<'r>, Status> {
+        self.1.respond_to(request)
+    }
+
+    fn name(&self) -> &'static str {
+        self.1.name()
+    }
+
+    fn source(&'r self) -> Option<&'r (dyn TypedError<'r> + 'r)> {
+        Some(&self.1)
+    }
+
+    fn status(&self) -> Status {
+        self.0
+    }
+}
+
+impl<'r> TypedError<'r> for std::convert::Infallible {  }
+
+impl<'r> TypedError<'r> for std::io::Error {
+    fn status(&self) -> Status {
+        match self.kind() {
+            std::io::ErrorKind::NotFound => Status::NotFound,
+            std::io::ErrorKind::PermissionDenied => Status::Unauthorized,
+            std::io::ErrorKind::AlreadyExists => Status::Conflict,
+            std::io::ErrorKind::InvalidInput => Status::BadRequest,
+            _ => Status::InternalServerError,
+        }
+    }
+}
+
+impl<'r> TypedError<'r> for std::num::ParseIntError {
+    fn status(&self) -> Status { Status::BadRequest }
+}
+
+impl<'r> TypedError<'r> for std::num::ParseFloatError {
+    fn status(&self) -> Status { Status::BadRequest }
+}
+
+impl<'r> TypedError<'r> for std::string::FromUtf8Error {
+    fn status(&self) -> Status { Status::BadRequest }
+}
+
+#[cfg(feature = "json")]
+impl<'r> TypedError<'r> for serde_json::Error {
+    fn status(&self) -> Status { Status::BadRequest }
+}
+
+#[cfg(feature = "msgpack")]
+impl<'r> TypedError<'r> for rmp_serde::encode::Error { }
+
+#[cfg(feature = "msgpack")]
+impl<'r> TypedError<'r> for rmp_serde::decode::Error {
+    fn status(&self) -> Status { Status::BadRequest }
+}
+
+// // TODO: This is a hack to make any static type implement Transient
+// impl<'r, T: std::fmt::Debug + Send + Sync + 'static> TypedError<'r> for response::Debug<T> {
+//     fn respond_to(&self, request: &'r Request<'_>) -> Result<Response<'r>, Status> {
+//         format!("{:?}", self.0).respond_to(request).responder_error()
+//     }
+// }
+
+impl<'r, L, R> TypedError<'r> for Either<L, R>
+    where L: TypedError<'r> + Transient,
+          L::Transience: CanTranscendTo<Inv<'r>>,
+          R: TypedError<'r> + Transient,
+          R::Transience: CanTranscendTo<Inv<'r>>,
+{
+    fn respond_to(&self, request: &'r Request<'_>) -> Result<Response<'r>, Status> {
+        match self {
+            Self::Left(v) => v.respond_to(request),
+            Self::Right(v) => v.respond_to(request),
+        }
+    }
+
+    fn name(&self) -> &'static str {
+        match self {
+            Self::Left(v) => v.name(),
+            Self::Right(v) => v.name(),
+        }
+    }
+
+    fn source(&'r self) -> Option<&'r (dyn TypedError<'r> + 'r)> {
+        match self {
+            Self::Left(v) => Some(v),
+            Self::Right(v) => Some(v),
+        }
+    }
+
+    fn status(&self) -> Status {
+        match self {
+            Self::Left(v) => v.status(),
+            Self::Right(v) => v.status(),
+        }
+    }
+}
+
+// // TODO: This cannot be used as a bound on an untyped catcher to get any error type.
+// // This is mostly an implementation detail (and issue with double boxing) for
+// // the responder derive
+// // We should just get rid of this. `&dyn TypedError<'_>` impls `FromError`
+// #[derive(Transient)]
+// pub struct AnyError<'r>(pub Box<dyn TypedError<'r> + 'r>);
+
+// impl<'r> TypedError<'r> for AnyError<'r> {
+//     fn source(&'r self) -> Option<&'r (dyn TypedError<'r> + 'r)> {
+//         Some(self.0.as_ref())
+//     }
+
+//     fn respond_to(&self, request: &'r Request<'_>) -> Result<Response<'r>, Status> {
+//         self.0.respond_to(request)
+//     }
+
+//     fn name(&self) -> &'static str { self.0.name() }
+
+//     fn status(&self) -> Status { self.0.status() }
+// }
+
+/// Validates that a type implements `TypedError`. Used by the `#[catch]` attribute to ensure
+/// the `TypeError` is first in the diagnostics.
+#[doc(hidden)]
+pub fn type_id_of<'r, T: TypedError<'r> + Transient + 'r>() -> (TypeId, &'static str) {
+    (TypeId::of::<T>(), std::any::type_name::<T>())
+}
+
+/// Downcast an error type to the underlying concrete type. Used by the `#[catch]` attribute.
+#[doc(hidden)]
+pub fn downcast<'r, T>(v: Option<&'r dyn TypedError<'r>>) -> Option<&'r T>
+    where T: TypedError<'r> + Transient + 'r,
+          T::Transience: CanRecoverFrom<Inv<'r>>,
+{
+    // if v.is_none() {
+    //     crate::trace::error!("No value to downcast from");
+    // }
+    let v = v?;
+    // crate::trace::error!("Downcasting error from {}", v.name());
+    v.as_any().downcast_ref()
+}
+
+/// Upcasts a value to `Box<dyn Error<'r>>`, falling back to a default if it doesn't implement
+/// `Error`
+#[doc(hidden)]
+#[macro_export]
+macro_rules! resolve_typed_catcher {
+    ($T:expr) => ({
+        #[allow(unused_imports)]
+        use $crate::catcher::resolution::{Resolve, DefaultTypeErase, ResolvedTypedError};
+
+        let inner = Resolve::new($T).cast();
+        ResolvedTypedError {
+            name: inner.as_ref().ok().map(|e| e.name()),
+            val: inner,
+        }
+    });
+}
+
+pub use resolve_typed_catcher;
+
+pub mod resolution {
+    use std::marker::PhantomData;
+
+    use transient::{CanTranscendTo, Transient};
+
+    use super::*;
+
+    /// The *magic*.
+    ///
+    /// `Resolve<T>::item` for `T: Transient` is `<T as Transient>::item`.
+    /// `Resolve<T>::item` for `T: !Transient` is `DefaultTypeErase::item`.
+    ///
+    /// This _must_ be used as `Resolve::<T>:item` for resolution to work. This
+    /// is a fun, static dispatch hack for "specialization" that works because
+    /// Rust prefers inherent methods over blanket trait impl methods.
+    pub struct Resolve<'r, T: 'r>(pub T, PhantomData<&'r ()>);
+
+    impl<'r, T: 'r> Resolve<'r, T> {
+        pub fn new(val: T) -> Self {
+            Self(val, PhantomData)
+        }
+    }
+
+    /// Fallback trait "implementing" `Transient` for all types. This is what
+    /// Rust will resolve `Resolve<T>::item` to when `T: !Transient`.
+    pub trait DefaultTypeErase<'r>: Sized {
+        const SPECIALIZED: bool = false;
+
+        fn cast(self) -> Result<Box<dyn TypedError<'r>>, Self> { Err(self) }
+    }
+
+    impl<'r, T: 'r> DefaultTypeErase<'r> for Resolve<'r, T> {}
+
+    /// "Specialized" "implementation" of `Transient` for `T: Transient`. This is
+    /// what Rust will resolve `Resolve<T>::item` to when `T: Transient`.
+    impl<'r, T: TypedError<'r> + Transient> Resolve<'r, T>
+        where T::Transience: CanTranscendTo<Inv<'r>>
+    {
+        pub const SPECIALIZED: bool = true;
+
+        pub fn cast(self) -> Result<Box<dyn TypedError<'r>>, Self> { Ok(Box::new(self.0)) }
+    }
+
+    // TODO: These extensions maybe useful, but so far not really
+    // // Box<dyn _> can be upcast without double boxing?
+    // impl<'r> Resolve<'r, Box<dyn TypedError<'r>>> {
+    //     pub const SPECIALIZED: bool = true;
+
+    //     pub fn cast(self) -> Result<Box<dyn TypedError<'r>>, Self> { Ok(self.0) }
+    // }
+
+    // Ideally, we should be able to handle this case, but we can't, since we don't own `Either`
+    // impl<'r, A, B> Resolve<'r, Either<A, B>>
+    //     where A: TypedError<'r> + Transient,
+    //           A::Transience: CanTranscendTo<Inv<'r>>,
+    //           B: TypedError<'r> + Transient,
+    //           B::Transience: CanTranscendTo<Inv<'r>>,
+    // {
+    //     pub const SPECIALIZED: bool = true;
+
+    //     pub fn cast(self) -> Result<Box<dyn TypedError<'r>>, Self> { Ok(Box::new(self.0)) }
+    // }
+
+    /// Wrapper type to hold the return type of `resolve_typed_catcher`.
+    #[doc(hidden)]
+    pub struct ResolvedTypedError<'r, T> {
+        /// The return value from `TypedError::name()`, if Some
+        pub name: Option<&'static str>,
+        /// The upcast error, if it supports it
+        pub val: Result<Box<dyn TypedError<'r> + 'r>, Resolve<'r, T>>,
+    }
+}

--- a/core/lib/src/config/config.rs
+++ b/core/lib/src/config/config.rs
@@ -430,9 +430,10 @@ impl Provider for Config {
 
 #[crate::async_trait]
 impl<'r> FromRequest<'r> for &'r Config {
+    type Forward = std::convert::Infallible;
     type Error = std::convert::Infallible;
 
-    async fn from_request(req: &'r Request<'_>) -> request::Outcome<Self, Self::Error> {
+    async fn from_request(req: &'r Request<'_>) -> request::Outcome<Self, Self::Error, Self::Forward> {
         request::Outcome::Success(req.rocket().config())
     }
 }

--- a/core/lib/src/config/config.rs
+++ b/core/lib/src/config/config.rs
@@ -433,7 +433,9 @@ impl<'r> FromRequest<'r> for &'r Config {
     type Forward = std::convert::Infallible;
     type Error = std::convert::Infallible;
 
-    async fn from_request(req: &'r Request<'_>) -> request::Outcome<Self, Self::Error, Self::Forward> {
+    async fn from_request(req: &'r Request<'_>) ->
+        request::Outcome<Self, Self::Error, Self::Forward>
+    {
         request::Outcome::Success(req.rocket().config())
     }
 }

--- a/core/lib/src/config/secret_key.rs
+++ b/core/lib/src/config/secret_key.rs
@@ -182,9 +182,10 @@ impl PartialEq for SecretKey {
 
 #[crate::async_trait]
 impl<'r> FromRequest<'r> for &'r SecretKey {
+    type Forward = std::convert::Infallible;
     type Error = std::convert::Infallible;
 
-    async fn from_request(req: &'r Request<'_>) -> Outcome<Self, Self::Error> {
+    async fn from_request(req: &'r Request<'_>) -> Outcome<Self, Self::Error, Self::Forward> {
         Outcome::Success(&req.rocket().config().secret_key)
     }
 }

--- a/core/lib/src/data/capped.rs
+++ b/core/lib/src/data/capped.rs
@@ -260,10 +260,10 @@ macro_rules! impl_strict_from_data_from_capped {
                     Success(p) if p.is_complete() => Success(p.into_inner()),
                     Success(_) => {
                         let e = Error::new(UnexpectedEof, "data limit exceeded");
-                        Error((Status::BadRequest, e.into()))
+                        Error(e.into())
                     },
                     Forward(d) => Forward(d),
-                    Error((s, e)) => Error((s, e)),
+                    Error(e) => Error(e),
                 }
             }
         }

--- a/core/lib/src/data/capped.rs
+++ b/core/lib/src/data/capped.rs
@@ -205,7 +205,7 @@ use crate::response::{self, Responder};
 use crate::request::Request;
 
 impl<'r, 'o: 'r, T: Responder<'r, 'o>> Responder<'r, 'o> for Capped<T> {
-    fn respond_to(self, request: &'r Request<'_>) -> response::Result<'o> {
+    fn respond_to(self, request: &'r Request<'_>) -> response::Result<'r, 'o> {
         self.value.respond_to(request)
     }
 }

--- a/core/lib/src/data/data.rs
+++ b/core/lib/src/data/data.rs
@@ -114,7 +114,7 @@ impl<'r> Data<'r> {
     /// use rocket::data::{Data, FromData, Outcome};
     /// use rocket::http::Status;
     /// # struct MyType;
-    /// # #[derive(rocket::TypedError)]
+    /// # #[derive(rocket::TypedError, Debug)]
     /// # struct MyError;
     ///
     /// #[rocket::async_trait]

--- a/core/lib/src/data/data.rs
+++ b/core/lib/src/data/data.rs
@@ -114,7 +114,8 @@ impl<'r> Data<'r> {
     /// use rocket::data::{Data, FromData, Outcome};
     /// use rocket::http::Status;
     /// # struct MyType;
-    /// # type MyError = String;
+    /// # #[derive(rocket::TypedError)]
+    /// # struct MyError;
     ///
     /// #[rocket::async_trait]
     /// impl<'r> FromData<'r> for MyType {
@@ -122,7 +123,7 @@ impl<'r> Data<'r> {
     ///
     ///     async fn from_data(r: &'r Request<'_>, mut data: Data<'r>) -> Outcome<'r, Self> {
     ///         if data.peek(2).await != b"hi" {
-    ///             return Outcome::Forward((data, Status::BadRequest))
+    ///             return Outcome::Forward((data, MyError))
     ///         }
     ///
     ///         /* .. */

--- a/core/lib/src/data/from_data.rs
+++ b/core/lib/src/data/from_data.rs
@@ -1,3 +1,5 @@
+use std::fmt;
+
 use crate::catcher::TypedError;
 use crate::http::RawStr;
 use crate::request::{Request, local_cache};
@@ -182,7 +184,7 @@ pub type Outcome<'r, T, E = <T as FromData<'r>>::Error>
 /// use rocket::request::Request;
 /// use rocket::data::{self, Data, FromData};
 /// # struct MyType;
-/// # #[derive(rocket::TypedError)]
+/// # #[derive(rocket::TypedError, Debug)]
 /// # struct MyError;
 ///
 /// #[rocket::async_trait]
@@ -312,7 +314,7 @@ pub type Outcome<'r, T, E = <T as FromData<'r>>::Error>
 #[crate::async_trait]
 pub trait FromData<'r>: Sized {
     /// The associated error to be returned when the guard fails.
-    type Error: TypedError<'r> + 'r;
+    type Error: TypedError<'r> + fmt::Debug + 'r;
 
     /// Asynchronously validates, parses, and converts an instance of `Self`
     /// from the incoming request body data.

--- a/core/lib/src/data/limits.rs
+++ b/core/lib/src/data/limits.rs
@@ -316,7 +316,7 @@ impl Limits {
 impl<'r> FromRequest<'r> for &'r Limits {
     type Forward = std::convert::Infallible;
     type Error = std::convert::Infallible;
-    
+
     async fn from_request(req: &'r Request<'_>) -> Outcome<Self, Self::Error, Self::Forward> {
         Outcome::Success(req.limits())
     }

--- a/core/lib/src/data/limits.rs
+++ b/core/lib/src/data/limits.rs
@@ -314,9 +314,10 @@ impl Limits {
 
 #[crate::async_trait]
 impl<'r> FromRequest<'r> for &'r Limits {
+    type Forward = std::convert::Infallible;
     type Error = std::convert::Infallible;
-
-    async fn from_request(req: &'r Request<'_>) -> Outcome<Self, Self::Error> {
+    
+    async fn from_request(req: &'r Request<'_>) -> Outcome<Self, Self::Error, Self::Forward> {
         Outcome::Success(req.limits())
     }
 }

--- a/core/lib/src/erased.rs
+++ b/core/lib/src/erased.rs
@@ -65,7 +65,7 @@ pub struct ErasedResponse {
     // XXX: SAFETY: This (dependent) field must come first due to drop order!
     response: Response<'static>,
     // XXX: SAFETY: This (dependent) field must come second due to drop order!
-    error: ErrorBox,
+    _error: ErrorBox,
     _request: Arc<ErasedRequest>,
 }
 
@@ -151,7 +151,7 @@ impl ErasedRequest {
 
         ErasedResponse {
             _request: parent,
-            error,
+            _error: error,
             response,
         }
     }

--- a/core/lib/src/error.rs
+++ b/core/lib/src/error.rs
@@ -5,7 +5,10 @@ use std::error::Error as StdError;
 use std::sync::Arc;
 
 use figment::Profile;
+use transient::Static;
 
+use crate::http::Status;
+use crate::catcher::TypedError;
 use crate::listener::Endpoint;
 use crate::{Catcher, Ignite, Orbit, Phase, Rocket, Route};
 use crate::trace::Trace;
@@ -88,6 +91,13 @@ pub enum ErrorKind {
 /// An error that occurs when a value was unexpectedly empty.
 #[derive(Clone, Copy, Default, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct Empty;
+
+impl Static for Empty {}
+impl<'r> TypedError<'r> for Empty {
+    fn status(&self) -> Status {
+        Status::BadRequest
+    }
+}
 
 /// An error that occurs when a value doesn't match one of the expected options.
 ///

--- a/core/lib/src/error.rs
+++ b/core/lib/src/error.rs
@@ -8,6 +8,7 @@ use figment::Profile;
 use transient::Static;
 
 use crate::http::Status;
+use crate::TypedError;
 use crate::catcher::TypedError;
 use crate::listener::Endpoint;
 use crate::{Catcher, Ignite, Orbit, Phase, Rocket, Route};
@@ -93,6 +94,7 @@ pub enum ErrorKind {
 pub struct Empty;
 
 impl Static for Empty {}
+
 impl<'r> TypedError<'r> for Empty {
     fn status(&self) -> Status {
         Status::BadRequest
@@ -129,7 +131,8 @@ impl<'r> TypedError<'r> for Empty {
 ///     }
 /// }
 /// ```
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, TypedError)]
+#[error(status = 400)]
 #[non_exhaustive]
 pub struct InvalidOption<'a> {
     /// The value that was provided.

--- a/core/lib/src/fairing/fairings.rs
+++ b/core/lib/src/fairing/fairings.rs
@@ -166,11 +166,11 @@ impl Fairings {
     }
 
     #[inline(always)]
-    pub async fn handle_request_filter<'r>(&self, req: &'r Request<'_>, data: &mut Data<'_>)
+    pub async fn handle_request_filter<'r>(&self, req: &'r Request<'_>)
         -> Result<(), Box<dyn TypedError<'r> + 'r>>
     {
         for fairing in iter!(self.request_filter) {
-            fairing.on_request_filter(req, data).await?;
+            fairing.on_request_filter(req).await?;
         }
         Ok(())
     }
@@ -227,6 +227,7 @@ impl std::fmt::Debug for Fairings {
             .field("launch", &debug_info(iter!(self.ignite)))
             .field("liftoff", &debug_info(iter!(self.liftoff)))
             .field("request", &debug_info(iter!(self.request)))
+            .field("request_filter", &debug_info(iter!(self.request_filter)))
             .field("response", &debug_info(iter!(self.response)))
             .field("shutdown", &debug_info(iter!(self.shutdown)))
             .finish()

--- a/core/lib/src/fairing/info_kind.rs
+++ b/core/lib/src/fairing/info_kind.rs
@@ -64,15 +64,18 @@ impl Kind {
     /// `Kind` flag representing a request for a 'request' callback.
     pub const Request: Kind = Kind(1 << 2);
 
+    /// `Kind` flag representing a request for a 'request' callback.
+    pub const RequestFilter: Kind = Kind(1 << 3);
+
     /// `Kind` flag representing a request for a 'response' callback.
-    pub const Response: Kind = Kind(1 << 3);
+    pub const Response: Kind = Kind(1 << 4);
 
     /// `Kind` flag representing a request for a 'shutdown' callback.
-    pub const Shutdown: Kind = Kind(1 << 4);
+    pub const Shutdown: Kind = Kind(1 << 5);
 
     /// `Kind` flag representing a
     /// [singleton](crate::fairing::Fairing#singletons) fairing.
-    pub const Singleton: Kind = Kind(1 << 5);
+    pub const Singleton: Kind = Kind(1 << 6);
 
     /// Returns `true` if `self` is a superset of `other`. In other words,
     /// returns `true` if all of the kinds in `other` are also in `self`.
@@ -144,6 +147,7 @@ impl std::fmt::Display for Kind {
         write("ignite", Kind::Ignite)?;
         write("liftoff", Kind::Liftoff)?;
         write("request", Kind::Request)?;
+        write("request_filter", Kind::RequestFilter)?;
         write("response", Kind::Response)?;
         write("shutdown", Kind::Shutdown)?;
         write("singleton", Kind::Singleton)

--- a/core/lib/src/fairing/info_kind.rs
+++ b/core/lib/src/fairing/info_kind.rs
@@ -39,6 +39,7 @@ pub struct Info {
 ///   * Ignite
 ///   * Liftoff
 ///   * Request
+///   * RequestFilter
 ///   * Response
 ///   * Shutdown
 ///

--- a/core/lib/src/fairing/mod.rs
+++ b/core/lib/src/fairing/mod.rs
@@ -163,14 +163,15 @@ pub type FilterResult<'r> = std::result::Result<(), Box<dyn TypedError<'r> + 'r>
 ///     is called just after a request is received, immediately after
 ///     pre-processing the request and running all `Request` fairings. This method
 ///     returns a `Result`, which can be used to terminate processing of a request,
-// TODO: Typed: links
-///     bypassing the routing process. The error value must be a `TypedError`, which
+///     bypassing the routing process. The error value must be a [`TypedError`], which
 ///     can then be caught by a typed catcher.
 ///
 ///     This method should only be used for global filters, i.e., filters that need
 ///     to be run on every (or very nearly every) route. One common example might be
 ///     CORS, since the CORS headers of every request need to be inspected, and potentially
 ///     rejected.
+///
+/// [`TypedError`]: crate::catcher::TypedError
 ///
 ///   * **<a name="response">Response</a> (`on_response`)**
 ///

--- a/core/lib/src/fairing/mod.rs
+++ b/core/lib/src/fairing/mod.rs
@@ -440,9 +440,10 @@ pub type FilterResult<'r> = std::result::Result<(), Box<dyn TypedError<'r> + 'r>
 /// // Allows a route to access the time a request was initiated.
 /// #[rocket::async_trait]
 /// impl<'r> FromRequest<'r> for StartTime {
+///     type Forward = std::convert::Infallible;
 ///     type Error = Status;
 ///
-///     async fn from_request(request: &'r Request<'_>) -> request::Outcome<Self, Self::Error> {
+///     async fn from_request(request: &'r Request<'_>) -> request::Outcome<Self, Self::Error, Self::Forward> {
 ///         match *request.local_cache(|| TimerStart(None)) {
 ///             TimerStart(Some(time)) => request::Outcome::Success(StartTime(time)),
 ///             TimerStart(None) => request::Outcome::Error(Status::InternalServerError),

--- a/core/lib/src/fairing/mod.rs
+++ b/core/lib/src/fairing/mod.rs
@@ -51,6 +51,7 @@
 
 use std::any::Any;
 
+use crate::catcher::TypedError;
 use crate::{Rocket, Request, Response, Data, Build, Orbit};
 
 mod fairings;
@@ -502,6 +503,24 @@ pub trait Fairing: Send + Sync + AsAny + 'static {
     ///
     /// The default implementation of this method does nothing.
     async fn on_request(&self, _req: &mut Request<'_>, _data: &mut Data<'_>) {}
+
+    /// The request filter callback.
+    ///
+    /// See [Fairing Callbacks](#request) for complete semantics.
+    ///
+    /// This method is called when a new request is received if `Kind::RequestFilter`
+    /// is in the `kind` field of the `Info` structure for this fairing. The
+    /// `&Request` parameter is the incoming request, and the `&Data`
+    /// parameter is the incoming data in the request.
+    ///
+    /// ## Default Implementation
+    ///
+    /// The default implementation of this method does nothing.
+    async fn on_request_filter<'r>(&self, _req: &'r Request<'_>, _data: &mut Data<'_>)
+        -> Result<(), Box<dyn TypedError<'r> + 'r>>
+    {
+        Ok (())
+    }
 
     /// The response callback.
     ///

--- a/core/lib/src/form/form.rs
+++ b/core/lib/src/form/form.rs
@@ -333,7 +333,7 @@ impl<'r, T: FromForm<'r>> FromData<'r> for Form<T> {
 
         match T::finalize(context) {
             Ok(value) => Outcome::Success(Form(value)),
-            Err(e) => Outcome::Error((e.status(), e)),
+            Err(e) => Outcome::Error(e),
         }
     }
 }

--- a/core/lib/src/form/from_form_field.rs
+++ b/core/lib/src/form/from_form_field.rs
@@ -297,7 +297,7 @@ impl<'v> FromFormField<'v> for Capped<&'v str> {
 
         match <Capped<&'v str> as FromData>::from_data(f.request, f.data).await {
             Outcome::Success(p) => Ok(p),
-            Outcome::Error((_, e)) => Err(e)?,
+            Outcome::Error(e) => Err(e.0)?,
             Outcome::Forward(..) => {
                 Err(Error::from(ErrorKind::Unexpected).with_entity(Entity::DataField))?
             }
@@ -318,7 +318,7 @@ impl<'v> FromFormField<'v> for Capped<String> {
 
         match <Capped<String> as FromData>::from_data(f.request, f.data).await {
             Outcome::Success(p) => Ok(p),
-            Outcome::Error((_, e)) => Err(e)?,
+            Outcome::Error(e) => Err(e.0)?,
             Outcome::Forward(..) => {
                 Err(Error::from(ErrorKind::Unexpected).with_entity(Entity::DataField))?
             }
@@ -354,7 +354,7 @@ impl<'v> FromFormField<'v> for Capped<&'v [u8]> {
 
         match <Capped<&'v [u8]> as FromData>::from_data(f.request, f.data).await {
             Outcome::Success(p) => Ok(p),
-            Outcome::Error((_, e)) => Err(e)?,
+            Outcome::Error(e) => Err(e.0)?,
             Outcome::Forward(..) => {
                 Err(Error::from(ErrorKind::Unexpected).with_entity(Entity::DataField))?
             }
@@ -412,7 +412,7 @@ static DATE_TIME_FMT2: &[FormatItem<'_>] =
 impl<'v> FromFormField<'v> for Date {
     fn from_value(field: ValueField<'v>) -> Result<'v, Self> {
         let date = Self::parse(field.value, &DATE_FMT)
-            .map_err(|e| Box::new(e) as Box<dyn std::error::Error + Send>)?;
+            .map_err(|e| Box::new(e) as Box<dyn std::error::Error + Send + Sync>)?;
 
         Ok(date)
     }
@@ -422,7 +422,7 @@ impl<'v> FromFormField<'v> for Time {
     fn from_value(field: ValueField<'v>) -> Result<'v, Self> {
         let time = Self::parse(field.value, &TIME_FMT1)
             .or_else(|_| Self::parse(field.value, &TIME_FMT2))
-            .map_err(|e| Box::new(e) as Box<dyn std::error::Error + Send>)?;
+            .map_err(|e| Box::new(e) as Box<dyn std::error::Error + Send + Sync>)?;
 
         Ok(time)
     }
@@ -432,7 +432,7 @@ impl<'v> FromFormField<'v> for PrimitiveDateTime {
     fn from_value(field: ValueField<'v>) -> Result<'v, Self> {
         let dt = Self::parse(field.value, &DATE_TIME_FMT1)
             .or_else(|_| Self::parse(field.value, &DATE_TIME_FMT2))
-            .map_err(|e| Box::new(e) as Box<dyn std::error::Error + Send>)?;
+            .map_err(|e| Box::new(e) as Box<dyn std::error::Error + Send + Sync>)?;
 
         Ok(dt)
     }

--- a/core/lib/src/form/parser.rs
+++ b/core/lib/src/form/parser.rs
@@ -36,7 +36,10 @@ impl<'r, 'i> Parser<'r, 'i> {
             Some(c) if c.is_form() => Self::from_form(req, data).await,
             Some(c) if c.is_form_data() => Self::from_multipart(req, data).await,
             _ => return Outcome::Forward((data, Error {
-                name: None, value: None, kind: ErrorKind::UnsupportedMediaType, entity: Entity::Form,
+                name: None,
+                value: None,
+                kind: ErrorKind::UnsupportedMediaType,
+                entity: Entity::Form,
             }.into())),
         };
 

--- a/core/lib/src/fs/named_file.rs
+++ b/core/lib/src/fs/named_file.rs
@@ -152,7 +152,7 @@ impl NamedFile {
 /// you would like to stream a file with a different Content-Type than that
 /// implied by its extension, use a [`File`] directly.
 impl<'r> Responder<'r, 'static> for NamedFile {
-    fn respond_to(self, req: &'r Request<'_>) -> response::Result<'static> {
+    fn respond_to(self, req: &'r Request<'_>) -> response::Result<'r, 'static> {
         let mut response = self.1.respond_to(req)?;
         if let Some(ext) = self.0.extension() {
             if let Some(ct) = ContentType::from_extension(&ext.to_string_lossy()) {

--- a/core/lib/src/http/cookies.rs
+++ b/core/lib/src/http/cookies.rs
@@ -108,9 +108,10 @@ pub use cookie::{Cookie, SameSite, Iter};
 ///
 /// #[rocket::async_trait]
 /// impl<'r> FromRequest<'r> for User {
-///     type Error = Status;
+///     type Forward = Status;
+///     type Error = std::convert::Infallible;
 ///
-///     async fn from_request(request: &'r Request<'_>) -> request::Outcome<Self, Self::Error> {
+///     async fn from_request(request: &'r Request<'_>) -> request::Outcome<Self, Self::Error, Self::Forward> {
 ///         request.cookies()
 ///             .get_private("user_id")
 ///             .and_then(|c| c.value().parse().ok())

--- a/core/lib/src/http/cookies.rs
+++ b/core/lib/src/http/cookies.rs
@@ -98,7 +98,7 @@ pub use cookie::{Cookie, SameSite, Iter};
 ///
 /// ```rust
 /// # #[macro_use] extern crate rocket;
-/// # #[cfg(feature = "secrets")] {
+/// # #[cfg(feature = "secrets")] mod secrets {
 /// use rocket::http::Status;
 /// use rocket::request::{self, Request, FromRequest};
 /// use rocket::outcome::IntoOutcome;

--- a/core/lib/src/http/cookies.rs
+++ b/core/lib/src/http/cookies.rs
@@ -108,7 +108,7 @@ pub use cookie::{Cookie, SameSite, Iter};
 ///
 /// #[rocket::async_trait]
 /// impl<'r> FromRequest<'r> for User {
-///     type Error = std::convert::Infallible;
+///     type Error = Status;
 ///
 ///     async fn from_request(request: &'r Request<'_>) -> request::Outcome<Self, Self::Error> {
 ///         request.cookies()

--- a/core/lib/src/lib.rs
+++ b/core/lib/src/lib.rs
@@ -179,7 +179,7 @@ mod erased;
 #[doc(inline)] pub use crate::rkt::Rocket;
 #[doc(inline)] pub use crate::shutdown::Shutdown;
 #[doc(inline)] pub use crate::state::State;
-#[doc(inline)] pub use crate::state::StateMissing;
+#[doc(inline)] pub use crate::state::StateError;
 
 /// Retrofits support for `async fn` in trait impls and declarations.
 ///

--- a/core/lib/src/lib.rs
+++ b/core/lib/src/lib.rs
@@ -179,6 +179,7 @@ mod erased;
 #[doc(inline)] pub use crate::rkt::Rocket;
 #[doc(inline)] pub use crate::shutdown::Shutdown;
 #[doc(inline)] pub use crate::state::State;
+#[doc(inline)] pub use crate::state::StateMissing;
 
 /// Retrofits support for `async fn` in trait impls and declarations.
 ///

--- a/core/lib/src/lifecycle.rs
+++ b/core/lib/src/lifecycle.rs
@@ -100,14 +100,14 @@ impl Rocket<Orbit> {
         _token: RequestToken,
         request: &'r Request<'s>,
         error_box: &mut ErrorBox,
-        mut data: Data<'r>,
+        data: Data<'r>,
         // io_stream: impl Future<Output = io::Result<IoStream>> + Send,
     ) -> Response<'r> {
         // Remember if the request is `HEAD` for later body stripping.
         let was_head_request = request.method() == Method::Head;
 
         // Run request filter
-        let mut response = if let Err(error) = self.fairings.handle_request_filter(request, &mut data).await {
+        let mut response = if let Err(error) = self.fairings.handle_request_filter(request).await {
             let error = error_box.write(error);
             self.dispatch_error(error, request).await
         } else {

--- a/core/lib/src/lifecycle.rs
+++ b/core/lib/src/lifecycle.rs
@@ -297,6 +297,7 @@ impl Rocket<Orbit> {
     /// Return `Ok(result)` if the handler succeeded. Returns `Ok(Some(Status))`
     /// if the handler ran to completion but failed. Returns `Ok(None)` if the
     /// handler panicked while executing.
+    // TODO: Typed: Docs
     async fn invoke_catcher<'s, 'r: 's>(
         &'s self,
         error: &'r dyn TypedError<'r>,

--- a/core/lib/src/lifecycle.rs
+++ b/core/lib/src/lifecycle.rs
@@ -298,7 +298,7 @@ impl Rocket<Orbit> {
         error: &'r dyn TypedError<'r>,
         req: &'r Request<'s>,
         depth: usize,
-    ) -> Option<(&'s Catcher, &'r dyn TypedError<'r>)> {
+    ) -> Option<(&'s Catcher, &'r (dyn TypedError<'r> + 'r))> {
         const MAX_CALLS_TO_SOURCE: usize = 5;
         if depth > MAX_CALLS_TO_SOURCE {
             return None;

--- a/core/lib/src/local/asynchronous/request.rs
+++ b/core/lib/src/local/asynchronous/request.rs
@@ -92,8 +92,8 @@ impl<'c> LocalRequest<'c> {
             // _shouldn't_ error. Check that now and error only if not.
             if self.inner().uri() == invalid {
                 error!("invalid request URI: {:?}", invalid.path());
-                return LocalResponse::new(self.request, move |req| {
-                    rocket.dispatch_error(Status::BadRequest, req)
+                return LocalResponse::new(self.request, move |req, error_box| {
+                    rocket.dispatch_error(error_box.write(Box::new(Status::BadRequest)), req)
                 }).await
             }
         }
@@ -101,8 +101,8 @@ impl<'c> LocalRequest<'c> {
         // Actually dispatch the request.
         let mut data = Data::local(self.data);
         let token = rocket.preprocess(&mut self.request, &mut data).await;
-        let response = LocalResponse::new(self.request, move |req| {
-            rocket.dispatch(token, req, data)
+        let response = LocalResponse::new(self.request, move |req, error_box| {
+            rocket.dispatch(token, req, error_box, data)
         }).await;
 
         // If the client is tracking cookies, updates the internal cookie jar

--- a/core/lib/src/local/asynchronous/response.rs
+++ b/core/lib/src/local/asynchronous/response.rs
@@ -58,7 +58,7 @@ pub struct LocalResponse<'c> {
     // XXX: SAFETY: This (dependent) field must come first due to drop order!
     response: Response<'c>,
     // XXX: SAFETY: This (dependent) field must come second due to drop order!
-    error: ErrorBox,
+    _error: ErrorBox,
     cookies: CookieJar<'c>,
     _request: Box<Request<'c>>,
 }
@@ -108,7 +108,7 @@ impl<'c> LocalResponse<'c> {
                 cookies.add_original(cookie.into_owned());
             }
 
-            LocalResponse { _request: boxed_req, error: error_box, cookies, response, }
+            LocalResponse { _request: boxed_req, _error: error_box, cookies, response, }
         }
     }
 }

--- a/core/lib/src/mtls/certificate.rs
+++ b/core/lib/src/mtls/certificate.rs
@@ -2,7 +2,6 @@ use ref_cast::RefCast;
 
 use crate::mtls::{x509, oid, bigint, Name, Result, Error};
 use crate::request::{Request, FromRequest, Outcome};
-use crate::http::Status;
 
 /// A request guard for validated, verified client certificates.
 ///
@@ -117,7 +116,7 @@ impl<'r> FromRequest<'r> for Certificate<'r> {
         let certs: Outcome<_, Error> = req.connection
             .peer_certs
             .as_ref()
-            .or_forward(Status::Unauthorized);
+            .or_forward(Error::Empty);
 
         let chain = try_outcome!(certs);
         Certificate::parse(chain.inner()).or_error(())

--- a/core/lib/src/mtls/certificate.rs
+++ b/core/lib/src/mtls/certificate.rs
@@ -55,7 +55,7 @@ use crate::request::{Request, FromRequest, Outcome};
 ///         if let Some(true) = cert.has_serial(ADMIN_SERIAL) {
 ///             Outcome::Success(CertifiedAdmin(cert))
 ///         } else {
-///             Outcome::Forward(Status::Unauthorized)
+///             Outcome::Forward(mtls::Error::SubjectUnauthorized)
 ///         }
 ///     }
 /// }

--- a/core/lib/src/mtls/certificate.rs
+++ b/core/lib/src/mtls/certificate.rs
@@ -48,9 +48,10 @@ use crate::request::{Request, FromRequest, Outcome};
 ///
 /// #[rocket::async_trait]
 /// impl<'r> FromRequest<'r> for CertifiedAdmin<'r> {
+///     type Forward = mtls::Error;
 ///     type Error = mtls::Error;
 ///
-///     async fn from_request(req: &'r Request<'_>) -> Outcome<Self, Self::Error> {
+///     async fn from_request(req: &'r Request<'_>) -> Outcome<Self, Self::Error, Self::Forward> {
 ///         let cert = try_outcome!(req.guard::<Certificate<'r>>().await);
 ///         if let Some(true) = cert.has_serial(ADMIN_SERIAL) {
 ///             Outcome::Success(CertifiedAdmin(cert))

--- a/core/lib/src/mtls/certificate.rs
+++ b/core/lib/src/mtls/certificate.rs
@@ -108,12 +108,13 @@ pub use rustls::pki_types::CertificateDer;
 
 #[crate::async_trait]
 impl<'r> FromRequest<'r> for Certificate<'r> {
+    type Forward = Error;
     type Error = Error;
 
-    async fn from_request(req: &'r Request<'_>) -> Outcome<Self, Self::Error> {
+    async fn from_request(req: &'r Request<'_>) -> Outcome<Self, Error, Error> {
         use crate::outcome::{try_outcome, IntoOutcome};
 
-        let certs: Outcome<_, Error> = req.connection
+        let certs: Outcome<_, Error, Error> = req.connection
             .peer_certs
             .as_ref()
             .or_forward(Error::Empty);

--- a/core/lib/src/mtls/certificate.rs
+++ b/core/lib/src/mtls/certificate.rs
@@ -114,13 +114,13 @@ impl<'r> FromRequest<'r> for Certificate<'r> {
     async fn from_request(req: &'r Request<'_>) -> Outcome<Self, Self::Error> {
         use crate::outcome::{try_outcome, IntoOutcome};
 
-        let certs = req.connection
+        let certs: Outcome<_, Error> = req.connection
             .peer_certs
             .as_ref()
             .or_forward(Status::Unauthorized);
 
         let chain = try_outcome!(certs);
-        Certificate::parse(chain.inner()).or_error(Status::Unauthorized)
+        Certificate::parse(chain.inner()).or_error(())
     }
 }
 

--- a/core/lib/src/mtls/error.rs
+++ b/core/lib/src/mtls/error.rs
@@ -1,7 +1,10 @@
 use std::fmt;
 use std::num::NonZeroUsize;
 
-use crate::mtls::x509::{self, nom};
+use transient::Static;
+
+use crate::{catcher::TypedError, mtls::x509::{self, nom}};
+use crate::http::Status;
 
 /// An error returned by the [`Certificate`](crate::mtls::Certificate) guard.
 ///
@@ -39,6 +42,12 @@ pub enum Error {
     Incomplete(Option<NonZeroUsize>),
     /// The certificate contained `.0` bytes of trailing data.
     Trailing(usize),
+}
+
+impl Static for Error {}
+
+impl<'r> TypedError<'r> for Error {
+    fn status(&self) -> Status { Status::Unauthorized }
 }
 
 impl fmt::Display for Error {

--- a/core/lib/src/mtls/error.rs
+++ b/core/lib/src/mtls/error.rs
@@ -42,6 +42,8 @@ pub enum Error {
     Incomplete(Option<NonZeroUsize>),
     /// The certificate contained `.0` bytes of trailing data.
     Trailing(usize),
+    /// The subject is not authorized
+    SubjectUnauthorized,
 }
 
 impl Static for Error {}
@@ -59,6 +61,7 @@ impl fmt::Display for Error {
             Error::Empty => write!(f, "empty certificate chain"),
             Error::NoSubject => write!(f, "empty subject without subjectAlt"),
             Error::NonCriticalSubjectAlt => write!(f, "empty subject without critical subjectAlt"),
+            Error::SubjectUnauthorized => write!(f, "subject not permitted"),
         }
     }
 }

--- a/core/lib/src/outcome.rs
+++ b/core/lib/src/outcome.rs
@@ -769,14 +769,14 @@ impl<'r, T: FromData<'r>> IntoOutcome<data::Outcome<'r, T>> for Result<T, T::Err
 }
 
 impl<S, E> IntoOutcome<request::Outcome<S, E>> for Result<S, E> {
-    type Error = Status;
+    type Error = ();
     type Forward = Status;
 
     #[inline]
-    fn or_error(self, error: Status) -> request::Outcome<S, E> {
+    fn or_error(self, _: ()) -> request::Outcome<S, E> {
         match self {
             Ok(val) => Success(val),
-            Err(err) => Error((error, err))
+            Err(err) => Error(err)
         }
     }
 

--- a/core/lib/src/outcome.rs
+++ b/core/lib/src/outcome.rs
@@ -86,9 +86,7 @@
 //! a type of `Option<S>`. If an `Outcome` is a `Forward`, the `Option` will be
 //! `None`.
 
-use crate::catcher::TypedError;
-use crate::{route, request, response};
-use crate::data::Data;
+use crate::request;
 
 use self::Outcome::*;
 
@@ -746,12 +744,12 @@ impl<S, E, F> IntoOutcome<Outcome<S, E, F>> for Option<S> {
     }
 }
 
-impl<S, E> IntoOutcome<request::Outcome<S, E>> for Result<S, E> {
+impl<S, E, F> IntoOutcome<request::Outcome<S, E, F>> for Result<S, E> {
     type Error = ();
-    type Forward = E;
+    type Forward = F;
 
     #[inline]
-    fn or_error(self, _: ()) -> request::Outcome<S, E> {
+    fn or_error(self, _: ()) -> request::Outcome<S, E, F> {
         match self {
             Ok(val) => Success(val),
             Err(err) => Error(err)
@@ -759,7 +757,7 @@ impl<S, E> IntoOutcome<request::Outcome<S, E>> for Result<S, E> {
     }
 
     #[inline]
-    fn or_forward(self, status: E) -> request::Outcome<S, E> {
+    fn or_forward(self, status: F) -> request::Outcome<S, E, F> {
         match self {
             Ok(val) => Success(val),
             Err(_) => Forward(status)
@@ -767,25 +765,25 @@ impl<S, E> IntoOutcome<request::Outcome<S, E>> for Result<S, E> {
     }
 }
 
-impl<'r, 'o: 'r> IntoOutcome<route::Outcome<'r>> for response::Result<'r, 'o> {
-    type Error = ();
-    type Forward = (Data<'r>, Box<dyn TypedError<'r> + 'r>);
+// impl<'r, 'o: 'r> IntoOutcome<route::Outcome<'r>> for response::Result<'r, 'o> {
+//     type Error = ();
+//     type Forward = (Data<'r>, Box<dyn TypedError<'r> + 'r>);
 
-    #[inline]
-    fn or_error(self, _: ()) -> route::Outcome<'r> {
-        match self {
-            Ok(val) => Success(val),
-            Err(status) => Error(status),
-        }
-    }
+//     #[inline]
+//     fn or_error(self, _: ()) -> route::Outcome<'r> {
+//         match self {
+//             Ok(val) => Success(val),
+//             Err(status) => Error(status),
+//         }
+//     }
 
-    #[inline]
-    fn or_forward(self,
-        (data, forward): (Data<'r>, Box<dyn TypedError<'r> + 'r>)
-    ) -> route::Outcome<'r> {
-        match self {
-            Ok(val) => Success(val),
-            Err(_) => Forward((data, forward))
-        }
-    }
-}
+//     #[inline]
+//     fn or_forward(self,
+//         (data, forward): (Data<'r>, Box<dyn TypedError<'r> + 'r>)
+//     ) -> route::Outcome<'r> {
+//         match self {
+//             Ok(val) => Success(val),
+//             Err(_) => Forward((data, forward))
+//         }
+//     }
+// }

--- a/core/lib/src/outcome.rs
+++ b/core/lib/src/outcome.rs
@@ -780,7 +780,9 @@ impl<'r, 'o: 'r> IntoOutcome<route::Outcome<'r>> for response::Result<'r, 'o> {
     }
 
     #[inline]
-    fn or_forward(self, (data, forward): (Data<'r>, Box<dyn TypedError<'r> + 'r>)) -> route::Outcome<'r> {
+    fn or_forward(self,
+        (data, forward): (Data<'r>, Box<dyn TypedError<'r> + 'r>)
+    ) -> route::Outcome<'r> {
         match self {
             Ok(val) => Success(val),
             Err(_) => Forward((data, forward))

--- a/core/lib/src/request/from_param.rs
+++ b/core/lib/src/request/from_param.rs
@@ -160,7 +160,7 @@ use crate::http::{uri::{Segments, error::PathError, fmt::Path}, Status};
 /// use rocket::TypedError;
 /// # #[allow(dead_code)]
 /// # struct MyParam<'r> { key: &'r str, value: usize }
-/// #[derive(TypedError)]
+/// #[derive(TypedError, Debug)]
 /// struct MyParamError<'a>(&'a str);
 ///
 /// impl<'r> FromParam<'r> for MyParam<'r> {
@@ -192,7 +192,7 @@ use crate::http::{uri::{Segments, error::PathError, fmt::Path}, Status};
 /// # #[macro_use] extern crate rocket;
 /// # use rocket::request::FromParam;
 /// # use rocket::TypedError;
-/// # #[derive(TypedError)]
+/// # #[derive(TypedError, Debug)]
 /// # struct MyParamError<'a>(&'a str);
 /// # #[allow(dead_code)]
 /// # struct MyParam<'r> { key: &'r str, value: usize }
@@ -215,7 +215,7 @@ use crate::http::{uri::{Segments, error::PathError, fmt::Path}, Status};
 /// ```
 pub trait FromParam<'a>: Sized {
     /// The associated error to be returned if parsing/validation fails.
-    type Error: TypedError<'a>;
+    type Error: TypedError<'a> + fmt::Debug + 'a;
 
     /// Parses and validates an instance of `Self` from a path parameter string
     /// or returns an `Error` if parsing or validation fails.
@@ -397,7 +397,7 @@ impl<'a, T: FromParam<'a>> FromParam<'a> for Option<T> {
 /// the `Utf8Error`.
 pub trait FromSegments<'r>: Sized {
     /// The associated error to be returned when parsing fails.
-    type Error: TypedError<'r>;
+    type Error: TypedError<'r> + fmt::Debug + 'r;
 
     /// Parses an instance of `Self` from many dynamic path parameter strings or
     /// returns an `Error` if one cannot be parsed.

--- a/core/lib/src/request/from_request.rs
+++ b/core/lib/src/request/from_request.rs
@@ -1,4 +1,5 @@
 use std::convert::Infallible;
+use std::fmt;
 use std::net::{IpAddr, SocketAddr};
 
 use crate::catcher::TypedError;
@@ -36,7 +37,7 @@ pub type Outcome<S, E> = outcome::Outcome<S, E, E>;
 /// use rocket::request::{self, Request, FromRequest};
 /// # struct MyType;
 /// # use rocket::TypedError;
-/// # #[derive(TypedError)]
+/// # #[derive(TypedError, Debug)]
 /// # struct MyError;
 ///
 /// #[rocket::async_trait]
@@ -408,7 +409,7 @@ pub type Outcome<S, E> = outcome::Outcome<S, E, E>;
 #[crate::async_trait]
 pub trait FromRequest<'r>: Sized {
     /// The associated error to be returned if derivation fails.
-    type Error: TypedError<'r> + 'r;
+    type Error: TypedError<'r> + fmt::Debug + 'r;
 
     /// Derives an instance of `Self` from the incoming request metadata.
     ///

--- a/core/lib/src/request/from_request.rs
+++ b/core/lib/src/request/from_request.rs
@@ -41,9 +41,10 @@ pub type Outcome<T, E, F> = crate::outcome::Outcome<T, E, F>;
 ///
 /// #[rocket::async_trait]
 /// impl<'r> FromRequest<'r> for MyType {
+///     type Forward = MyError;
 ///     type Error = MyError;
 ///
-///     async fn from_request(req: &'r Request<'_>) -> request::Outcome<Self, Self::Error> {
+///     async fn from_request(req: &'r Request<'_>) -> request::Outcome<Self, Self::Error, Self::Forward> {
 ///         /* .. */
 ///         # unimplemented!()
 ///     }
@@ -220,9 +221,10 @@ pub type Outcome<T, E, F> = crate::outcome::Outcome<T, E, F>;
 ///
 /// #[rocket::async_trait]
 /// impl<'r> FromRequest<'r> for ApiKey<'r> {
+///     type Forward = std::convert::Infallible;
 ///     type Error = ApiKeyError;
 ///
-///     async fn from_request(req: &'r Request<'_>) -> Outcome<Self, Self::Error> {
+///     async fn from_request(req: &'r Request<'_>) -> Outcome<Self, Self::Error, Self::Forward> {
 ///         /// Returns true if `key` is a valid API key string.
 ///         fn is_valid(key: &str) -> bool {
 ///             key == "valid_api_key"
@@ -293,8 +295,9 @@ pub type Outcome<T, E, F> = crate::outcome::Outcome<T, E, F>;
 /// # }
 /// # #[rocket::async_trait]
 /// # impl<'r> FromRequest<'r> for Database {
+/// #     type Forward = Status;
 /// #     type Error = Status;
-/// #     async fn from_request(request: &'r Request<'_>) -> Outcome<Database, Self::Error> {
+/// #     async fn from_request(request: &'r Request<'_>) -> Outcome<Database, Self::Error, Self::Forward> {
 /// #         Outcome::Success(Database)
 /// #     }
 /// # }
@@ -303,9 +306,10 @@ pub type Outcome<T, E, F> = crate::outcome::Outcome<T, E, F>;
 /// #
 /// #[rocket::async_trait]
 /// impl<'r> FromRequest<'r> for User {
+///     type Forward = Status;
 ///     type Error = Status;
 ///
-///     async fn from_request(request: &'r Request<'_>) -> Outcome<User, Status> {
+///     async fn from_request(request: &'r Request<'_>) -> Outcome<User, Self::Error, Self::Forward> {
 ///         let db = try_outcome!(request.guard::<Database>().await);
 ///         request.cookies()
 ///             .get_private("user_id")
@@ -317,9 +321,10 @@ pub type Outcome<T, E, F> = crate::outcome::Outcome<T, E, F>;
 ///
 /// #[rocket::async_trait]
 /// impl<'r> FromRequest<'r> for Admin {
+///     type Forward = Status;
 ///     type Error = Status;
 ///
-///     async fn from_request(request: &'r Request<'_>) -> Outcome<Admin, Status> {
+///     async fn from_request(request: &'r Request<'_>) -> Outcome<Admin, Self::Error, Self::Forward> {
 ///         // This will unconditionally query the database!
 ///         let user = try_outcome!(request.guard::<User>().await);
 ///         if user.is_admin {
@@ -358,8 +363,9 @@ pub type Outcome<T, E, F> = crate::outcome::Outcome<T, E, F>;
 /// # }
 /// # #[rocket::async_trait]
 /// # impl<'r> FromRequest<'r> for Database {
+/// #     type Forward = ();
 /// #     type Error = ();
-/// #     async fn from_request(request: &'r Request<'_>) -> Outcome<Database, ()> {
+/// #     async fn from_request(request: &'r Request<'_>) -> Outcome<Database, (), ()> {
 /// #         Outcome::Success(Database)
 /// #     }
 /// # }
@@ -368,9 +374,10 @@ pub type Outcome<T, E, F> = crate::outcome::Outcome<T, E, F>;
 /// #
 /// #[rocket::async_trait]
 /// impl<'r> FromRequest<'r> for &'r User {
+///     type Forward = Status;
 ///     type Error = Status;
 ///
-///     async fn from_request(request: &'r Request<'_>) -> Outcome<Self, Self::Error> {
+///     async fn from_request(request: &'r Request<'_>) -> Outcome<Self, Self::Error, Self::Forward> {
 ///         // This closure will execute at most once per request, regardless of
 ///         // the number of times the `User` guard is executed.
 ///         let user_result = request.local_cache_async(async {
@@ -387,9 +394,10 @@ pub type Outcome<T, E, F> = crate::outcome::Outcome<T, E, F>;
 ///
 /// #[rocket::async_trait]
 /// impl<'r> FromRequest<'r> for Admin<'r> {
+///     type Forward = Status;
 ///     type Error = Status;
 ///
-///     async fn from_request(request: &'r Request<'_>) -> Outcome<Self, Self::Error> {
+///     async fn from_request(request: &'r Request<'_>) -> Outcome<Self, Self::Error, Self::Forward> {
 ///         let user = try_outcome!(request.guard::<&User>().await);
 ///         if user.is_admin {
 ///             Outcome::Success(Admin { user })

--- a/core/lib/src/request/from_request.rs
+++ b/core/lib/src/request/from_request.rs
@@ -81,7 +81,7 @@ pub type Outcome<S, E> = outcome::Outcome<S, E, E>;
 ///   the value for the corresponding parameter.  As long as all other guards
 ///   succeed, the request will be handled.
 ///
-/// * **Error**(Status, E)
+/// * **Error**(E)
 ///
 ///   If the `Outcome` is [`Error`], the request will fail with the given
 ///   status code and error. The designated error [`Catcher`](crate::Catcher)
@@ -89,7 +89,7 @@ pub type Outcome<S, E> = outcome::Outcome<S, E, E>;
 ///   of `Result<S, E>` and `Option<S>` to catch `Error`s and retrieve the
 ///   error value.
 ///
-/// * **Forward**(Status)
+/// * **Forward**(E)
 ///
 ///   If the `Outcome` is [`Forward`], the request will be forwarded to the next
 ///   matching route until either one succeeds or there are no further matching
@@ -242,6 +242,32 @@ pub type Outcome<S, E> = outcome::Outcome<S, E, E>;
 /// }
 /// ```
 ///
+/// ## Errors
+///
+/// When a request guard fails, the error type can be caught using a catcher. A catcher
+/// for the above example might look something like this:
+///
+/// ```rust
+/// # #[macro_use] extern crate rocket;
+/// # use rocket::http::Status;
+/// # use rocket::request::{self, Outcome, Request, FromRequest};
+/// # #[derive(Debug, TypedError)]
+/// # #[error(status = 400)]
+/// # enum ApiKeyError {
+/// #     Missing,
+/// #     Invalid,
+/// # }
+/// #[catch(400, error = "<e>")]
+/// fn catch_api_key_error(e: &ApiKeyError) -> &'static str {
+///     match e {
+///         ApiKeyError::Missing => "Api key required",
+///         ApiKeyError::Invalid => "Api key is invalid",
+///     }
+/// }
+/// ```
+///
+/// See [typed catchers](crate::catch) for more information.
+///
 /// # Request-Local State
 ///
 /// Request guards that perform expensive operations, such as those that query a
@@ -379,7 +405,6 @@ pub type Outcome<S, E> = outcome::Outcome<S, E, E>;
 /// User` and `Admin<'a>`) as the data is now owned by the request's cache.
 ///
 /// [request-local state]: https://rocket.rs/master/guide/state/#request-local-state
-// TODO: Typed: docs
 #[crate::async_trait]
 pub trait FromRequest<'r>: Sized {
     /// The associated error to be returned if derivation fails.

--- a/core/lib/src/request/mod.rs
+++ b/core/lib/src/request/mod.rs
@@ -10,7 +10,7 @@ mod tests;
 
 pub use self::request::Request;
 pub use self::from_request::{FromRequest, Outcome};
-pub use self::from_param::{FromParam, FromSegments};
+pub use self::from_param::{FromParam, FromParamError, FromSegments, FromSegmentsError};
 
 #[doc(hidden)]
 pub use rocket_codegen::FromParam;

--- a/core/lib/src/request/request.rs
+++ b/core/lib/src/request/request.rs
@@ -819,7 +819,7 @@ impl<'r> Request<'r> {
     /// # })
     /// ```
     #[inline(always)]
-    pub fn guard<'z, 'a, T>(&'a self) -> BoxFuture<'z, Outcome<T, T::Error>>
+    pub fn guard<'z, 'a, T>(&'a self) -> BoxFuture<'z, Outcome<T, T::Error, T::Forward>>
         where T: FromRequest<'a> + 'z, 'a: 'z, 'r: 'z
     {
         T::from_request(self)

--- a/core/lib/src/response/content.rs
+++ b/core/lib/src/response/content.rs
@@ -58,7 +58,7 @@ macro_rules! ctrs {
             /// Sets the Content-Type of the response then delegates the
             /// remainder of the response to the wrapped responder.
             impl<'r, 'o: 'r, R: Responder<'r, 'o>> Responder<'r, 'o> for $name<R> {
-                fn respond_to(self, req: &'r Request<'_>) -> response::Result<'o> {
+                fn respond_to(self, req: &'r Request<'_>) -> response::Result<'r, 'o> {
                     (ContentType::$ct, self.0).respond_to(req)
                 }
             }
@@ -78,7 +78,7 @@ ctrs! {
 }
 
 impl<'r, 'o: 'r, R: Responder<'r, 'o>> Responder<'r, 'o> for (ContentType, R) {
-    fn respond_to(self, req: &'r Request<'_>) -> response::Result<'o> {
+    fn respond_to(self, req: &'r Request<'_>) -> response::Result<'r, 'o> {
         Response::build()
             .merge(self.1.respond_to(req)?)
             .header(self.0)

--- a/core/lib/src/response/debug.rs
+++ b/core/lib/src/response/debug.rs
@@ -1,6 +1,11 @@
+use transient::Static;
+
+use crate::catcher::TypedError;
 use crate::request::Request;
 use crate::response::{self, Responder};
 use crate::http::Status;
+
+use super::Response;
 
 /// Debug prints the internal value before forwarding to the 500 error catcher.
 ///
@@ -81,6 +86,17 @@ impl<'r, E: std::fmt::Debug> Responder<'r, 'static> for Debug<E> {
         Err(Box::new(Status::InternalServerError))
     }
 }
+
+// TODO: Typed: This is a stop-gap measure to allow any 'static type to be a `TypedError`
+impl<'r, E: std::fmt::Debug + Send + Sync + 'static> TypedError<'r> for Debug<E> {
+    fn respond_to(&self, _: &'r Request<'_>) -> Result<Response<'r>, Status> {
+        let type_name = std::any::type_name::<E>();
+        info!(type_name, value = ?self.0, "debug response (500)");
+        Err(Status::InternalServerError)
+    }
+}
+
+impl<E: Send + Sync + 'static> Static for Debug<E> { }
 
 /// Prints a warning with the error and forwards to the `500` error catcher.
 impl<'r> Responder<'r, 'static> for std::io::Error {

--- a/core/lib/src/response/debug.rs
+++ b/core/lib/src/response/debug.rs
@@ -88,6 +88,7 @@ impl<'r, E: std::fmt::Debug> Responder<'r, 'static> for Debug<E> {
 }
 
 // TODO: Typed: This is a stop-gap measure to allow any 'static type to be a `TypedError`
+// I think is going to be quite useful going forward, since most error types are 'static
 impl<'r, E: std::fmt::Debug + Send + Sync + 'static> TypedError<'r> for Debug<E> {
     fn respond_to(&self, _: &'r Request<'_>) -> Result<Response<'r>, Status> {
         let type_name = std::any::type_name::<E>();

--- a/core/lib/src/response/debug.rs
+++ b/core/lib/src/response/debug.rs
@@ -75,17 +75,17 @@ impl<E> From<E> for Debug<E> {
 }
 
 impl<'r, E: std::fmt::Debug> Responder<'r, 'static> for Debug<E> {
-    fn respond_to(self, _: &'r Request<'_>) -> response::Result<'static> {
+    fn respond_to(self, _: &'r Request<'_>) -> response::Result<'r, 'static> {
         let type_name = std::any::type_name::<E>();
         info!(type_name, value = ?self.0, "debug response (500)");
-        Err(Status::InternalServerError)
+        Err(Box::new(Status::InternalServerError))
     }
 }
 
 /// Prints a warning with the error and forwards to the `500` error catcher.
 impl<'r> Responder<'r, 'static> for std::io::Error {
-    fn respond_to(self, _: &'r Request<'_>) -> response::Result<'static> {
+    fn respond_to(self, _: &'r Request<'_>) -> response::Result<'r, 'static> {
         warn!("i/o error response: {self}");
-        Err(Status::InternalServerError)
+        Err(Box::new(Status::InternalServerError))
     }
 }

--- a/core/lib/src/response/flash.rs
+++ b/core/lib/src/response/flash.rs
@@ -52,13 +52,14 @@ const FLASH_COOKIE_DELIM: char = ':';
 /// # #[macro_use] extern crate rocket;
 /// use rocket::response::{Flash, Redirect};
 /// use rocket::request::FlashMessage;
+/// use rocket::either::Either;
 ///
 /// #[post("/login/<name>")]
-/// fn login(name: &str) -> Result<&'static str, Flash<Redirect>> {
+/// fn login(name: &str) -> Either<&'static str, Flash<Redirect>> {
 ///     if name == "special_user" {
-///         Ok("Hello, special user!")
+///         Either::Left("Hello, special user!")
 ///     } else {
-///         Err(Flash::error(Redirect::to(uri!(index)), "Invalid username."))
+///         Either::Right(Flash::error(Redirect::to(uri!(index)), "Invalid username."))
 ///     }
 /// }
 ///

--- a/core/lib/src/response/flash.rs
+++ b/core/lib/src/response/flash.rs
@@ -243,7 +243,7 @@ pub struct FlashCookieMissing;
 impl Static for FlashCookieMissing {}
 
 impl<'r> TypedError<'r> for FlashCookieMissing {
-    fn status(&self) -> Status { Status::InternalServerError }
+    fn status(&self) -> Status { Status::BadRequest }
 }
 
 /// Retrieves a flash message from a flash cookie. If there is no flash cookie,

--- a/core/lib/src/response/flash.rs
+++ b/core/lib/src/response/flash.rs
@@ -255,8 +255,9 @@ impl<'r> TypedError<'r> for FlashCookieMissing {
 #[crate::async_trait]
 impl<'r> FromRequest<'r> for FlashMessage<'r> {
     type Error = FlashCookieMissing;
+    type Forward = std::convert::Infallible;
 
-    async fn from_request(req: &'r Request<'_>) -> request::Outcome<Self, Self::Error> {
+    async fn from_request(req: &'r Request<'_>) -> request::Outcome<Self, Self::Error, Self::Forward> {
         req.cookies().get(FLASH_COOKIE_NAME).ok_or(FlashCookieMissing).and_then(|cookie| {
             // Parse the flash message.
             let content = cookie.value();

--- a/core/lib/src/response/flash.rs
+++ b/core/lib/src/response/flash.rs
@@ -189,7 +189,7 @@ impl<R> Flash<R> {
 /// response handling to the wrapped responder. As a result, the `Outcome` of
 /// the response is the `Outcome` of the wrapped `Responder`.
 impl<'r, 'o: 'r, R: Responder<'r, 'o>> Responder<'r, 'o> for Flash<R> {
-    fn respond_to(self, req: &'r Request<'_>) -> response::Result<'o> {
+    fn respond_to(self, req: &'r Request<'_>) -> response::Result<'r, 'o> {
         req.cookies().add(self.cookie());
         self.inner.respond_to(req)
     }

--- a/core/lib/src/response/flash.rs
+++ b/core/lib/src/response/flash.rs
@@ -257,7 +257,9 @@ impl<'r> FromRequest<'r> for FlashMessage<'r> {
     type Error = FlashCookieMissing;
     type Forward = std::convert::Infallible;
 
-    async fn from_request(req: &'r Request<'_>) -> request::Outcome<Self, Self::Error, Self::Forward> {
+    async fn from_request(req: &'r Request<'_>) ->
+        request::Outcome<Self, Self::Error, Self::Forward>
+    {
         req.cookies().get(FLASH_COOKIE_NAME).ok_or(FlashCookieMissing).and_then(|cookie| {
             // Parse the flash message.
             let content = cookie.value();

--- a/core/lib/src/response/mod.rs
+++ b/core/lib/src/response/mod.rs
@@ -38,4 +38,4 @@ pub use self::flash::Flash;
 pub use self::debug::Debug;
 
 /// Type alias for the `Result` of a [`Responder::respond_to()`] call.
-pub type Result<'r, 'o> = std::result::Result<Response<'o>, Box<dyn TypedError<'r>>>;
+pub type Result<'r, 'o> = std::result::Result<Response<'o>, Box<dyn TypedError<'r> + 'r>>;

--- a/core/lib/src/response/mod.rs
+++ b/core/lib/src/response/mod.rs
@@ -28,6 +28,8 @@ pub mod stream;
 #[doc(hidden)]
 pub use rocket_codegen::Responder;
 
+use crate::catcher::TypedError;
+
 pub use self::response::{Response, Builder};
 pub use self::body::Body;
 pub use self::responder::Responder;
@@ -36,4 +38,4 @@ pub use self::flash::Flash;
 pub use self::debug::Debug;
 
 /// Type alias for the `Result` of a [`Responder::respond_to()`] call.
-pub type Result<'r> = std::result::Result<Response<'r>, crate::http::Status>;
+pub type Result<'r, 'o> = std::result::Result<Response<'o>, Box<dyn TypedError<'r>>>;

--- a/core/lib/src/response/redirect.rs
+++ b/core/lib/src/response/redirect.rs
@@ -157,7 +157,7 @@ impl Redirect {
 /// value used to create the `Responder` is an invalid URI, an error of
 /// `Status::InternalServerError` is returned.
 impl<'r> Responder<'r, 'static> for Redirect {
-    fn respond_to(self, _: &'r Request<'_>) -> response::Result<'static> {
+    fn respond_to(self, _: &'r Request<'_>) -> response::Result<'r, 'static> {
         if let Some(uri) = self.1 {
             Response::build()
                 .status(self.0)
@@ -165,7 +165,7 @@ impl<'r> Responder<'r, 'static> for Redirect {
                 .ok()
         } else {
             error!("Invalid URI used for redirect.");
-            Err(Status::InternalServerError)
+            Err(Box::new(Status::InternalServerError))
         }
     }
 }

--- a/core/lib/src/response/responder.rs
+++ b/core/lib/src/response/responder.rs
@@ -174,7 +174,7 @@ use crate::request::Request;
 /// # struct A;
 /// // If the response contains no borrowed data.
 /// impl<'r> Responder<'r, 'static> for A {
-///     fn respond_to(self, _: &'r Request<'_>) -> response::Result<'static> {
+///     fn respond_to(self, _: &'r Request<'_>) -> response::Result<'r, 'static> {
 ///         todo!()
 ///     }
 /// }
@@ -182,7 +182,7 @@ use crate::request::Request;
 /// # struct B<'r>(&'r str);
 /// // If the response borrows from the request.
 /// impl<'r> Responder<'r, 'r> for B<'r> {
-///     fn respond_to(self, _: &'r Request<'_>) -> response::Result<'r> {
+///     fn respond_to(self, _: &'r Request<'_>) -> response::Result<'r, 'r> {
 ///         todo!()
 ///     }
 /// }
@@ -190,7 +190,7 @@ use crate::request::Request;
 /// # struct C;
 /// // If the response is or wraps a borrow that may outlive the request.
 /// impl<'r, 'o: 'r> Responder<'r, 'o> for &'o C {
-///     fn respond_to(self, _: &'r Request<'_>) -> response::Result<'o> {
+///     fn respond_to(self, _: &'r Request<'_>) -> response::Result<'r, 'o> {
 ///         todo!()
 ///     }
 /// }
@@ -198,7 +198,7 @@ use crate::request::Request;
 /// # struct D<R>(R);
 /// // If the response wraps an existing responder.
 /// impl<'r, 'o: 'r, R: Responder<'r, 'o>> Responder<'r, 'o> for D<R> {
-///     fn respond_to(self, _: &'r Request<'_>) -> response::Result<'o> {
+///     fn respond_to(self, _: &'r Request<'_>) -> response::Result<'r, 'o> {
 ///         todo!()
 ///     }
 /// }
@@ -248,7 +248,7 @@ use crate::request::Request;
 /// use rocket::http::ContentType;
 ///
 /// impl<'r> Responder<'r, 'static> for Person {
-///     fn respond_to(self, req: &'r Request<'_>) -> response::Result<'static> {
+///     fn respond_to(self, req: &'r Request<'_>) -> response::Result<'r, 'static> {
 ///         let string = format!("{}:{}", self.name, self.age);
 ///         Response::build_from(string.respond_to(req)?)
 ///             .raw_header("X-Person-Name", self.name)

--- a/core/lib/src/response/responder.rs
+++ b/core/lib/src/response/responder.rs
@@ -549,7 +549,6 @@ impl<'r> Responder<'r, 'static> for Status {
                     "invalid status used as responder\n\
                     status must be one of 100, 200..=205, 400..=599");
 
-                // TODO: Typed: Invalid status
                 Err(Box::new(Status::InternalServerError))
             }
         }

--- a/core/lib/src/response/status.rs
+++ b/core/lib/src/response/status.rs
@@ -323,7 +323,9 @@ macro_rules! status_response {
 
             fn name(&self) -> &'static str { self.0.name() }
 
-            fn source(&'r self) -> Option<&'r (dyn TypedError<'r> + 'r)> { Some(&self.0) }
+            fn source(&'r self, idx: usize) -> Option<&'r (dyn TypedError<'r> + 'r)> {
+                if idx == 0 { Some(&self.0) } else { None }
+            }
 
             fn status(&self) -> Status { Status::$T }
         }

--- a/core/lib/src/response/stream/bytes.rs
+++ b/core/lib/src/response/stream/bytes.rs
@@ -64,7 +64,7 @@ impl<S> From<S> for ByteStream<S> {
 impl<'r, S: Stream> Responder<'r, 'r> for ByteStream<S>
     where S: Send + 'r, S::Item: AsRef<[u8]> + Send + Unpin + 'r
 {
-    fn respond_to(self, _: &'r Request<'_>) -> response::Result<'r> {
+    fn respond_to(self, _: &'r Request<'_>) -> response::Result<'r, 'r> {
         Response::build()
             .header(ContentType::Binary)
             .streamed_body(ReaderStream::from(self.0.map(std::io::Cursor::new)))

--- a/core/lib/src/response/stream/reader.rs
+++ b/core/lib/src/response/stream/reader.rs
@@ -39,7 +39,7 @@ pin_project! {
     /// impl<'r, S: Stream<Item = String>> Responder<'r, 'r> for MyStream<S>
     ///     where S: Send + 'r
     /// {
-    ///     fn respond_to(self, _: &'r Request<'_>) -> response::Result<'r> {
+    ///     fn respond_to(self, _: &'r Request<'_>) -> response::Result<'r, 'r> {
     ///         Response::build()
     ///             .header(ContentType::Text)
     ///             .streamed_body(ReaderStream::from(self.0.map(Cursor::new)))

--- a/core/lib/src/response/stream/reader.rs
+++ b/core/lib/src/response/stream/reader.rs
@@ -142,7 +142,7 @@ impl<S: Stream> From<S> for ReaderStream<S> {
 impl<'r, S: Stream> Responder<'r, 'r> for ReaderStream<S>
     where S: Send + 'r, S::Item: AsyncRead + Send,
 {
-    fn respond_to(self, _: &'r Request<'_>) -> response::Result<'r> {
+    fn respond_to(self, _: &'r Request<'_>) -> response::Result<'r, 'r> {
         Response::build()
             .streamed_body(self)
             .ok()

--- a/core/lib/src/response/stream/sse.rs
+++ b/core/lib/src/response/stream/sse.rs
@@ -569,7 +569,7 @@ impl<S: Stream<Item = Event>> From<S> for EventStream<S> {
 }
 
 impl<'r, S: Stream<Item = Event> + Send + 'r> Responder<'r, 'r> for EventStream<S> {
-    fn respond_to(self, _: &'r Request<'_>) -> response::Result<'r> {
+    fn respond_to(self, _: &'r Request<'_>) -> response::Result<'r, 'r> {
         Response::build()
             .header(ContentType::EventStream)
             .raw_header("Cache-Control", "no-cache")

--- a/core/lib/src/response/stream/text.rs
+++ b/core/lib/src/response/stream/text.rs
@@ -65,7 +65,7 @@ impl<S> From<S> for TextStream<S> {
 impl<'r, S: Stream> Responder<'r, 'r> for TextStream<S>
     where S: Send + 'r, S::Item: AsRef<str> + Send + Unpin + 'r
 {
-    fn respond_to(self, _: &'r Request<'_>) -> response::Result<'r> {
+    fn respond_to(self, _: &'r Request<'_>) -> response::Result<'r, 'r> {
         struct ByteStr<T>(T);
 
         impl<T: AsRef<str>> AsRef<[u8]> for ByteStr<T> {

--- a/core/lib/src/route/handler.rs
+++ b/core/lib/src/route/handler.rs
@@ -1,10 +1,10 @@
+use crate::catcher::TypedError;
 use crate::{Request, Data};
 use crate::response::{Response, Responder};
-use crate::http::Status;
 
 /// Type alias for the return type of a [`Route`](crate::Route)'s
 /// [`Handler::handle()`].
-pub type Outcome<'r> = crate::outcome::Outcome<Response<'r>, Status, (Data<'r>, Status)>;
+pub type Outcome<'r> = crate::outcome::Outcome<Response<'r>, Box<dyn TypedError<'r>>, (Data<'r>, Box<dyn TypedError<'r>>)>;
 
 /// Type alias for the return type of a _raw_ [`Route`](crate::Route)'s
 /// [`Handler`].
@@ -233,8 +233,8 @@ impl<'r, 'o: 'r> Outcome<'o> {
     /// }
     /// ```
     #[inline(always)]
-    pub fn error(code: Status) -> Outcome<'r> {
-        Outcome::Error(code)
+    pub fn error<E: TypedError<'r>>(error: E) -> Outcome<'r> {
+        Outcome::Error(Box::new(error))
     }
 
     /// Return an `Outcome` of `Forward` with the data `data` and status
@@ -253,8 +253,8 @@ impl<'r, 'o: 'r> Outcome<'o> {
     /// }
     /// ```
     #[inline(always)]
-    pub fn forward(data: Data<'r>, status: Status) -> Outcome<'r> {
-        Outcome::Forward((data, status))
+    pub fn forward<E: TypedError<'r>>(data: Data<'r>, error: E) -> Outcome<'r> {
+        Outcome::Forward((data, Box::new(error)))
     }
 }
 

--- a/core/lib/src/route/handler.rs
+++ b/core/lib/src/route/handler.rs
@@ -4,7 +4,11 @@ use crate::response::{Response, Responder};
 
 /// Type alias for the return type of a [`Route`](crate::Route)'s
 /// [`Handler::handle()`].
-pub type Outcome<'r> = crate::outcome::Outcome<Response<'r>, Box<dyn TypedError<'r>>, (Data<'r>, Box<dyn TypedError<'r>>)>;
+pub type Outcome<'r> = crate::outcome::Outcome<
+    Response<'r>,
+    Box<dyn TypedError<'r>>,
+    (Data<'r>, Box<dyn TypedError<'r>>),
+>;
 
 /// Type alias for the return type of a _raw_ [`Route`](crate::Route)'s
 /// [`Handler`].

--- a/core/lib/src/route/handler.rs
+++ b/core/lib/src/route/handler.rs
@@ -133,6 +133,7 @@ pub type BoxFuture<'r, T = Outcome<'r>> = futures::future::BoxFuture<'r, T>;
 /// Use this alternative when a single configuration is desired and your custom
 /// handler is private to your application. For all other cases, a custom
 /// `Handler` implementation is preferred.
+// TODO: Typed: Docs
 #[crate::async_trait]
 pub trait Handler: Cloneable + Send + Sync + 'static {
     /// Called by Rocket when a `Request` with its associated `Data` should be

--- a/core/lib/src/route/handler.rs
+++ b/core/lib/src/route/handler.rs
@@ -30,6 +30,15 @@ pub type BoxFuture<'r, T = Outcome<'r>> = futures::future::BoxFuture<'r, T>;
 /// This is an _async_ trait. Implementations must be decorated
 /// [`#[rocket::async_trait]`](crate::async_trait).
 ///
+/// ## Errors
+///
+/// If the handler errors or forwards, the implementation must include a
+/// [`Box<dyn TypedError>`]. Any type that implements [`TypedError`] can
+/// be boxed upcast, see [`TypedError`] docs for more information.
+///
+/// [`Box<dyn TypedError>`]: crate::catcher::TypedError
+/// [`TypedError`]: crate::catcher::TypedError
+///
 /// # Example
 ///
 /// Say you'd like to write a handler that changes its functionality based on an
@@ -137,7 +146,6 @@ pub type BoxFuture<'r, T = Outcome<'r>> = futures::future::BoxFuture<'r, T>;
 /// Use this alternative when a single configuration is desired and your custom
 /// handler is private to your application. For all other cases, a custom
 /// `Handler` implementation is preferred.
-// TODO: Typed: Docs
 #[crate::async_trait]
 pub trait Handler: Cloneable + Send + Sync + 'static {
     /// Called by Rocket when a `Request` with its associated `Data` should be

--- a/core/lib/src/route/handler.rs
+++ b/core/lib/src/route/handler.rs
@@ -209,9 +209,9 @@ impl<'r, 'o: 'r> Outcome<'o> {
     /// ```
     #[inline]
     pub fn try_from<R, E>(req: &'r Request<'_>, result: Result<R, E>) -> Outcome<'r>
-        where R: Responder<'r, 'o>, E: std::fmt::Debug
+        where R: Responder<'r, 'o>, E: TypedError<'r> + 'r
     {
-        let responder = result.map_err(crate::response::Debug);
+        let responder = result;//.map_err(crate::response::Debug);
         match responder.respond_to(req) {
             Ok(response) => Outcome::Success(response),
             Err(status) => Outcome::Error(status)

--- a/core/lib/src/router/collider.rs
+++ b/core/lib/src/router/collider.rs
@@ -143,7 +143,7 @@ impl Catcher {
     pub fn collides_with(&self, other: &Self) -> bool {
         self.code == other.code
             && self.base().segments().eq(other.base().segments())
-            && self.type_id == other.type_id
+            && self.type_id() == other.type_id()
     }
 }
 

--- a/core/lib/src/router/collider.rs
+++ b/core/lib/src/router/collider.rs
@@ -141,7 +141,7 @@ impl Catcher {
     /// assert!(!a.collides_with(&b));
     /// ```
     pub fn collides_with(&self, other: &Self) -> bool {
-        self.code == other.code && self.base().segments().eq(other.base().segments())
+        self.code == other.code && self.base().segments().eq(other.base().segments()) && self.type_id == other.type_id
     }
 }
 

--- a/core/lib/src/router/collider.rs
+++ b/core/lib/src/router/collider.rs
@@ -141,7 +141,9 @@ impl Catcher {
     /// assert!(!a.collides_with(&b));
     /// ```
     pub fn collides_with(&self, other: &Self) -> bool {
-        self.code == other.code && self.base().segments().eq(other.base().segments()) && self.type_id == other.type_id
+        self.code == other.code
+            && self.base().segments().eq(other.base().segments())
+            && self.type_id == other.type_id
     }
 }
 

--- a/core/lib/src/router/matcher.rs
+++ b/core/lib/src/router/matcher.rs
@@ -120,14 +120,14 @@ impl Catcher {
     /// // Let's say `request` is `GET /` that 404s. The error matches only `a`:
     /// let request = client.get("/");
     /// # let request = request.inner();
-    /// assert!(a.matches(Status::NotFound, &request));
-    /// assert!(!b.matches(Status::NotFound, &request));
+    /// assert!(a.matches(Status::NotFound, None, &request));
+    /// assert!(!b.matches(Status::NotFound, None, &request));
     ///
     /// // Now `request` is a 404 `GET /bar`. The error matches `a` and `b`:
     /// let request = client.get("/bar");
     /// # let request = request.inner();
-    /// assert!(a.matches(Status::NotFound, &request));
-    /// assert!(b.matches(Status::NotFound, &request));
+    /// assert!(a.matches(Status::NotFound, None, &request));
+    /// assert!(b.matches(Status::NotFound, None, &request));
     ///
     /// // Note that because `b`'s base' has more complete segments that `a's,
     /// // Rocket would route the error to `b`, not `a`, even though both match.

--- a/core/lib/src/router/matcher.rs
+++ b/core/lib/src/router/matcher.rs
@@ -1,3 +1,5 @@
+use transient::TypeId;
+
 use crate::{Route, Request, Catcher};
 use crate::router::Collide;
 use crate::http::Status;
@@ -133,8 +135,9 @@ impl Catcher {
     /// let b_count = b.base().segments().filter(|s| !s.is_empty()).count();
     /// assert!(b_count > a_count);
     /// ```
-    pub fn matches(&self, status: Status, request: &Request<'_>) -> bool {
+    pub fn matches(&self, status: Status, ty: Option<TypeId>, request: &Request<'_>) -> bool {
         self.code.map_or(true, |code| code == status.code)
+            && self.type_id == ty
             && self.base().segments().prefix_of(request.uri().path().segments())
     }
 }

--- a/core/lib/src/router/matcher.rs
+++ b/core/lib/src/router/matcher.rs
@@ -137,7 +137,7 @@ impl Catcher {
     /// ```
     pub fn matches(&self, status: Status, ty: Option<TypeId>, request: &Request<'_>) -> bool {
         self.code.map_or(true, |code| code == status.code)
-            && self.type_id == ty
+            && self.type_id() == ty
             && self.base().segments().prefix_of(request.uri().path().segments())
     }
 }

--- a/core/lib/src/router/router.rs
+++ b/core/lib/src/router/router.rs
@@ -595,7 +595,7 @@ mod test {
         for (status, base, ty) in catchers {
             let mut catcher = Catcher::new(status.map(|s| s.code), catcher::dummy_handler)
                 .rebase(Origin::parse(base).unwrap());
-            catcher.type_id = ty;
+            catcher.type_info = ty.map(|t| ("", t));
             router.catchers.push(catcher);
         }
 
@@ -663,9 +663,14 @@ mod test {
             (None, "/", Some(TypeId::of::<()>()))
         ]).unwrap();
 
-        assert!(catches_any(&router, Status::BadRequest, "/", |_| None).unwrap().type_id.is_none());
         assert!(
-            catches_any(&router, Status::BadRequest, "/", |_| Some(&())).unwrap().type_id.is_some()
+            catches_any(&router, Status::BadRequest, "/", |_| None).unwrap().type_id().is_none()
+        );
+        assert!(
+            catches_any(&router, Status::BadRequest, "/", |_| Some(&()))
+                .unwrap()
+                .type_id()
+                .is_some()
         );
     }
 }

--- a/core/lib/src/router/router.rs
+++ b/core/lib/src/router/router.rs
@@ -589,7 +589,7 @@ mod test {
     fn catcher<'a>(r: &'a Router<Finalized>, status: Status, uri: &str) -> Option<&'a Catcher> {
         let client = Client::debug_with(vec![]).expect("client");
         let request = client.get(Origin::parse(uri).unwrap());
-        r.catch(status, &request)
+        r.catch(status, None, &request)
     }
 
     macro_rules! assert_catcher_routing {

--- a/core/lib/src/router/router.rs
+++ b/core/lib/src/router/router.rs
@@ -593,7 +593,8 @@ mod test {
     {
         let mut router = Router::new();
         for (status, base, ty) in catchers {
-            let mut catcher = Catcher::new(status.map(|s| s.code), catcher::dummy_handler).rebase(Origin::parse(base).unwrap());
+            let mut catcher = Catcher::new(status.map(|s| s.code), catcher::dummy_handler)
+                .rebase(Origin::parse(base).unwrap());
             catcher.type_id = ty;
             router.catchers.push(catcher);
         }
@@ -646,7 +647,7 @@ mod test {
         let request = client.req(Method::Get, Origin::parse(uri).unwrap());
         router.catch_any(status, ty(&()), &request)
     }
-    
+
     #[test]
     fn test_catch_vs_catch_any() {
         let router = make_router_catches([(None, "/", None)]).unwrap();

--- a/core/lib/src/router/router.rs
+++ b/core/lib/src/router/router.rs
@@ -107,7 +107,12 @@ impl Router<Finalized> {
 
     // For many catchers, using aho-corasick or similar should be much faster.
     #[track_caller]
-    pub fn catch<'r>(&self, status: Status, error: Option<&'r dyn TypedError<'r>>, req: &'r Request<'r>) -> Option<&Catcher> {
+    pub fn catch<'r>(
+        &self,
+        status: Status,
+        error: Option<&'r dyn TypedError<'r>>,
+        req: &'r Request<'r>
+    ) -> Option<&Catcher> {
         let ty = error.map(|e| e.trait_obj_typeid());
         // Note that catchers are presorted by descending base length.
         self.catcher_map.get(&Some(status.code))
@@ -116,7 +121,12 @@ impl Router<Finalized> {
     }
 
     #[track_caller]
-    pub fn catch_any<'r>(&self, status: Status, error: Option<&'r dyn TypedError<'r>>, req: &'r Request<'r>) -> Option<&Catcher> {
+    pub fn catch_any<'r>(
+        &self,
+        status: Status,
+        error: Option<&'r dyn TypedError<'r>>,
+        req: &'r Request<'r>
+    ) -> Option<&Catcher> {
         let ty = error.map(|e| e.trait_obj_typeid());
         // Note that catchers are presorted by descending base length.
         self.catcher_map.get(&None)
@@ -617,78 +627,79 @@ mod test {
 
     #[test]
     fn test_catcher_routing() {
-        // Check that the default `/` catcher catches everything.
-        assert_catcher_routing! {
-            catch: [(None, "/")],
-            reqs: [(404, "/a/b/c"), (500, "/a/b"), (415, "/a/b/d"), (422, "/a/b/c/d?foo")],
-            with: [(None, "/"), (None, "/"), (None, "/"), (None, "/")]
-        }
+        // TODO: Typed: update tests for new logic - catch got split into two methods.
+        // // Check that the default `/` catcher catches everything.
+        // assert_catcher_routing! {
+        //     catch: [(None, "/")],
+        //     reqs: [(404, "/a/b/c"), (500, "/a/b"), (415, "/a/b/d"), (422, "/a/b/c/d?foo")],
+        //     with: [(None, "/"), (None, "/"), (None, "/"), (None, "/")]
+        // }
 
-        // Check prefixes when they're exact.
-        assert_catcher_routing! {
-            catch: [(None, "/"), (None, "/a"), (None, "/a/b")],
-            reqs: [
-                (404, "/"), (500, "/"),
-                (404, "/a"), (500, "/a"),
-                (404, "/a/b"), (500, "/a/b")
-            ],
-            with: [
-                (None, "/"), (None, "/"),
-                (None, "/a"), (None, "/a"),
-                (None, "/a/b"), (None, "/a/b")
-            ]
-        }
+        // // Check prefixes when they're exact.
+        // assert_catcher_routing! {
+        //     catch: [(None, "/"), (None, "/a"), (None, "/a/b")],
+        //     reqs: [
+        //         (404, "/"), (500, "/"),
+        //         (404, "/a"), (500, "/a"),
+        //         (404, "/a/b"), (500, "/a/b")
+        //     ],
+        //     with: [
+        //         (None, "/"), (None, "/"),
+        //         (None, "/a"), (None, "/a"),
+        //         (None, "/a/b"), (None, "/a/b")
+        //     ]
+        // }
 
         // Check prefixes when they're not exact.
-        assert_catcher_routing! {
-            catch: [(None, "/"), (None, "/a"), (None, "/a/b")],
-            reqs: [
-                (404, "/foo"), (500, "/bar"), (422, "/baz/bar"), (418, "/poodle?yes"),
-                (404, "/a/foo"), (500, "/a/bar/baz"), (510, "/a/c"), (423, "/a/c/b"),
-                (404, "/a/b/c"), (500, "/a/b/c/d"), (500, "/a/b?foo"), (400, "/a/b/yes")
-            ],
-            with: [
-                (None, "/"), (None, "/"), (None, "/"), (None, "/"),
-                (None, "/a"), (None, "/a"), (None, "/a"), (None, "/a"),
-                (None, "/a/b"), (None, "/a/b"), (None, "/a/b"), (None, "/a/b")
-            ]
-        }
+        // assert_catcher_routing! {
+        //     catch: [(None, "/"), (None, "/a"), (None, "/a/b")],
+        //     reqs: [
+        //         (404, "/foo"), (500, "/bar"), (422, "/baz/bar"), (418, "/poodle?yes"),
+        //         (404, "/a/foo"), (500, "/a/bar/baz"), (510, "/a/c"), (423, "/a/c/b"),
+        //         (404, "/a/b/c"), (500, "/a/b/c/d"), (500, "/a/b?foo"), (400, "/a/b/yes")
+        //     ],
+        //     with: [
+        //         (None, "/"), (None, "/"), (None, "/"), (None, "/"),
+        //         (None, "/a"), (None, "/a"), (None, "/a"), (None, "/a"),
+        //         (None, "/a/b"), (None, "/a/b"), (None, "/a/b"), (None, "/a/b")
+        //     ]
+        // }
 
         // Check that we prefer specific to default.
-        assert_catcher_routing! {
-            catch: [(400, "/"), (404, "/"), (None, "/")],
-            reqs: [
-                (400, "/"), (400, "/bar"), (400, "/foo/bar"),
-                (404, "/"), (404, "/bar"), (404, "/foo/bar"),
-                (405, "/"), (405, "/bar"), (406, "/foo/bar")
-            ],
-            with: [
-                (400, "/"), (400, "/"), (400, "/"),
-                (404, "/"), (404, "/"), (404, "/"),
-                (None, "/"), (None, "/"), (None, "/")
-            ]
-        }
+        // assert_catcher_routing! {
+        //     catch: [(400, "/"), (404, "/"), (None, "/")],
+        //     reqs: [
+        //         (400, "/"), (400, "/bar"), (400, "/foo/bar"),
+        //         (404, "/"), (404, "/bar"), (404, "/foo/bar"),
+        //         (405, "/"), (405, "/bar"), (406, "/foo/bar")
+        //     ],
+        //     with: [
+        //         (400, "/"), (400, "/"), (400, "/"),
+        //         (404, "/"), (404, "/"), (404, "/"),
+        //         (None, "/"), (None, "/"), (None, "/")
+        //     ]
+        // }
 
         // Check that we prefer longer prefixes over specific.
-        assert_catcher_routing! {
-            catch: [(None, "/a/b"), (404, "/a"), (422, "/a")],
-            reqs: [
-                (404, "/a/b"), (404, "/a/b/c"), (422, "/a/b/c"),
-                (404, "/a"), (404, "/a/c"), (404, "/a/cat/bar"),
-                (422, "/a"), (422, "/a/c"), (422, "/a/cat/bar")
-            ],
-            with: [
-                (None, "/a/b"), (None, "/a/b"), (None, "/a/b"),
-                (404, "/a"), (404, "/a"), (404, "/a"),
-                (422, "/a"), (422, "/a"), (422, "/a")
-            ]
-        }
+        // assert_catcher_routing! {
+        //     catch: [(None, "/a/b"), (404, "/a"), (422, "/a")],
+        //     reqs: [
+        //         (404, "/a/b"), (404, "/a/b/c"), (422, "/a/b/c"),
+        //         (404, "/a"), (404, "/a/c"), (404, "/a/cat/bar"),
+        //         (422, "/a"), (422, "/a/c"), (422, "/a/cat/bar")
+        //     ],
+        //     with: [
+        //         (None, "/a/b"), (None, "/a/b"), (None, "/a/b"),
+        //         (404, "/a"), (404, "/a"), (404, "/a"),
+        //         (422, "/a"), (422, "/a"), (422, "/a")
+        //     ]
+        // }
 
         // Just a fun one.
-        assert_catcher_routing! {
-            catch: [(None, "/"), (None, "/a/b"), (500, "/a/b/c"), (500, "/a/b")],
-            reqs: [(404, "/a/b/c"), (500, "/a/b"), (400, "/a/b/d"), (500, "/a/b/c/d?foo")],
-            with: [(None, "/a/b"), (500, "/a/b"), (None, "/a/b"), (500, "/a/b/c")]
-        }
+        // assert_catcher_routing! {
+        //     catch: [(None, "/"), (None, "/a/b"), (500, "/a/b/c"), (500, "/a/b")],
+        //     reqs: [(404, "/a/b/c"), (500, "/a/b"), (400, "/a/b/d"), (500, "/a/b/c/d?foo")],
+        //     with: [(None, "/a/b"), (500, "/a/b"), (None, "/a/b"), (500, "/a/b/c")]
+        // }
     }
 }

--- a/core/lib/src/serde/json.rs
+++ b/core/lib/src/serde/json.rs
@@ -216,7 +216,7 @@ impl<'r, T: Deserialize<'r>> FromData<'r> for Json<T> {
 /// JSON and a fixed-size body with the serialized value. If serialization
 /// fails, an `Err` of `Status::InternalServerError` is returned.
 impl<'r, T: Serialize> Responder<'r, 'static> for Json<T> {
-    fn respond_to(self, req: &'r Request<'_>) -> response::Result<'static> {
+    fn respond_to(self, req: &'r Request<'_>) -> response::Result<'r, 'static> {
         let string = serde_json::to_string(&self.0)
             .map_err(|e| {
                 error!("JSON serialize failure: {}", e);
@@ -298,7 +298,7 @@ impl<'v, T: Deserialize<'v> + Send> form::FromFormField<'v> for Json<T> {
 /// Serializes the value into JSON. Returns a response with Content-Type JSON
 /// and a fixed-size body with the serialized value.
 impl<'r> Responder<'r, 'static> for Value {
-    fn respond_to(self, req: &'r Request<'_>) -> response::Result<'static> {
+    fn respond_to(self, req: &'r Request<'_>) -> response::Result<'r, 'static> {
         content::RawJson(self.to_string()).respond_to(req)
     }
 }

--- a/core/lib/src/serde/msgpack.rs
+++ b/core/lib/src/serde/msgpack.rs
@@ -198,16 +198,7 @@ impl<'r, T: Deserialize<'r>> FromData<'r> for MsgPack<T> {
     async fn from_data(req: &'r Request<'_>, data: Data<'r>) -> Outcome<'r, Self> {
         match Self::from_data(req, data).await {
             Ok(value) => Outcome::Success(value),
-            Err(Error::InvalidDataRead(e)) if e.kind() == io::ErrorKind::UnexpectedEof => {
-                Outcome::Error((Status::PayloadTooLarge, Error::InvalidDataRead(e)))
-            },
-            | Err(e@Error::TypeMismatch(_))
-            | Err(e@Error::OutOfRange)
-            | Err(e@Error::LengthMismatch(_))
-            => {
-                Outcome::Error((Status::UnprocessableEntity, e))
-            },
-            Err(e) => Outcome::Error((Status::BadRequest, e)),
+            Err(e) => Outcome::Error(e),
         }
     }
 }

--- a/core/lib/src/serde/msgpack.rs
+++ b/core/lib/src/serde/msgpack.rs
@@ -216,7 +216,7 @@ impl<'r, T: Deserialize<'r>> FromData<'r> for MsgPack<T> {
 /// Content-Type `MsgPack` and a fixed-size body with the serialization. If
 /// serialization fails, an `Err` of `Status::InternalServerError` is returned.
 impl<'r, T: Serialize, const COMPACT: bool> Responder<'r, 'static> for MsgPack<T, COMPACT> {
-    fn respond_to(self, req: &'r Request<'_>) -> response::Result<'static> {
+    fn respond_to(self, req: &'r Request<'_>) -> response::Result<'r, 'static> {
         let maybe_buf = if COMPACT {
             rmp_serde::to_vec(&self.0)
         } else {

--- a/core/lib/src/server.rs
+++ b/core/lib/src/server.rs
@@ -43,12 +43,12 @@ impl Rocket<Orbit> {
         let mut response = request.into_response(
             stream,
             |rocket, request, data| Box::pin(rocket.preprocess(request, data)),
-            |token, rocket, request, data| Box::pin(async move {
+            |token, rocket, request, error_box, data| Box::pin(async move {
                 if !request.errors.is_empty() {
-                    return rocket.dispatch_error(Status::BadRequest, request).await;
+                    return rocket.dispatch_error(error_box.write(Box::new(Status::BadRequest)), request).await;
                 }
 
-                rocket.dispatch(token, request, data).await
+                rocket.dispatch(token, request, error_box, data).await
             })
         ).await;
 

--- a/core/lib/src/server.rs
+++ b/core/lib/src/server.rs
@@ -45,7 +45,10 @@ impl Rocket<Orbit> {
             |rocket, request, data| Box::pin(rocket.preprocess(request, data)),
             |token, rocket, request, error_box, data| Box::pin(async move {
                 if !request.errors.is_empty() {
-                    return rocket.dispatch_error(error_box.write(Box::new(Status::BadRequest)), request).await;
+                    return rocket.dispatch_error(
+                        error_box.write(Box::new(Status::BadRequest)),
+                        request
+                    ).await;
                 }
 
                 rocket.dispatch(token, request, error_box, data).await

--- a/core/lib/src/shutdown/handle.rs
+++ b/core/lib/src/shutdown/handle.rs
@@ -136,10 +136,11 @@ impl Future for Shutdown {
 
 #[crate::async_trait]
 impl<'r> FromRequest<'r> for Shutdown {
+    type Forward = std::convert::Infallible;
     type Error = std::convert::Infallible;
 
     #[inline]
-    async fn from_request(request: &'r Request<'_>) -> Outcome<Self, Self::Error> {
+    async fn from_request(request: &'r Request<'_>) -> Outcome<Self, Self::Error, Self::Forward> {
         Outcome::Success(request.rocket().shutdown())
     }
 }

--- a/core/lib/src/state.rs
+++ b/core/lib/src/state.rs
@@ -72,9 +72,9 @@ use crate::http::Status;
 ///
 /// #[rocket::async_trait]
 /// impl<'r> FromRequest<'r> for Item<'r> {
-///     type Error = ();
+///     type Error = Status;
 ///
-///     async fn from_request(request: &'r Request<'_>) -> request::Outcome<Self, ()> {
+///     async fn from_request(request: &'r Request<'_>) -> request::Outcome<Self, Self::Error> {
 ///         // Using `State` as a request guard. Use `inner()` to get an `'r`.
 ///         let outcome = request.guard::<&State<MyConfig>>().await
 ///             .map(|my_config| Item(&my_config.user_val));

--- a/core/lib/src/state.rs
+++ b/core/lib/src/state.rs
@@ -1,3 +1,4 @@
+use std::convert::Infallible;
 use std::fmt;
 use std::ops::Deref;
 use std::any::type_name;
@@ -205,10 +206,11 @@ impl<'r> TypedError<'r> for StateError {
 
 #[crate::async_trait]
 impl<'r, T: Send + Sync + 'static> FromRequest<'r> for &'r State<T> {
+    type Forward = Infallible;
     type Error = StateError;
 
     #[inline(always)]
-    async fn from_request(req: &'r Request<'_>) -> request::Outcome<Self, Self::Error> {
+    async fn from_request(req: &'r Request<'_>) -> request::Outcome<Self, Self::Error, Infallible> {
         match State::get(req.rocket()) {
             Some(state) => Outcome::Success(state),
             None => {

--- a/core/lib/src/state.rs
+++ b/core/lib/src/state.rs
@@ -195,17 +195,17 @@ impl<'r, T: Send + Sync + 'static> From<&'r T> for &'r State<T> {
 
 /// Error for a managed state element not being present.
 #[derive(Debug, PartialEq, Eq)]
-pub struct StateMissing(pub &'static str);
+pub struct StateError(pub &'static str);
 
-impl Static for StateMissing {}
+impl Static for StateError {}
 
-impl<'r> TypedError<'r> for StateMissing {
+impl<'r> TypedError<'r> for StateError {
     fn status(&self) -> Status { Status::InternalServerError }
 }
 
 #[crate::async_trait]
 impl<'r, T: Send + Sync + 'static> FromRequest<'r> for &'r State<T> {
-    type Error = StateMissing;
+    type Error = StateError;
 
     #[inline(always)]
     async fn from_request(req: &'r Request<'_>) -> request::Outcome<Self, Self::Error> {
@@ -216,7 +216,7 @@ impl<'r, T: Send + Sync + 'static> FromRequest<'r> for &'r State<T> {
                 "retrieving unmanaged state\n\
                 state must be managed via `rocket.manage()`");
 
-                Outcome::Error(StateMissing(type_name::<T>()))
+                Outcome::Error(StateError(type_name::<T>()))
             }
         }
     }

--- a/core/lib/src/state.rs
+++ b/core/lib/src/state.rs
@@ -73,9 +73,10 @@ use crate::http::Status;
 ///
 /// #[rocket::async_trait]
 /// impl<'r> FromRequest<'r> for Item<'r> {
+///     type Forward = Status;
 ///     type Error = Status;
 ///
-///     async fn from_request(request: &'r Request<'_>) -> request::Outcome<Self, Self::Error> {
+///     async fn from_request(request: &'r Request<'_>) -> request::Outcome<Self, Self::Error, Self::Forward> {
 ///         // Using `State` as a request guard. Use `inner()` to get an `'r`.
 ///         let outcome = request.guard::<&State<MyConfig>>().await
 ///             .map(|my_config| Item(&my_config.user_val));

--- a/core/lib/src/trace/subscriber/pretty.rs
+++ b/core/lib/src/trace/subscriber/pretty.rs
@@ -118,6 +118,11 @@ impl<S: Subscriber + for<'a> LookupSpan<'a>> Layer<S> for RocketFmt<Pretty> {
                 }
 
                 write!(f, "{}", &data["uri.base"].paint(style.primary()))?;
+
+                if let Some(type_name) = data.get("type") {
+                    write!(f, " <{}>", &type_name.paint(style.dim()))?;
+                }
+
                 if let Some(name) = data.get("name") {
                     write!(f, " ({}", name.paint(style.bold().bright()))?;
 

--- a/core/lib/src/trace/traceable.rs
+++ b/core/lib/src/trace/traceable.rs
@@ -247,8 +247,8 @@ impl Trace for route::Outcome<'_> {
             },
             status = match self {
                 Self::Success(r) => r.status().code,
-                Self::Error(s) => s.code,
-                Self::Forward((_, s)) => s.code,
+                Self::Error(s) => s.status().code,
+                Self::Forward((_, s)) => s.status().code,
             },
         )
     }

--- a/core/lib/src/trace/traceable.rs
+++ b/core/lib/src/trace/traceable.rs
@@ -176,6 +176,7 @@ impl Trace for Catcher {
             }),
             rank = self.rank,
             uri.base = %self.base(),
+            "type" = self.type_name(),
             location = self.location.as_ref()
                 .map(|(file, line, _)| Formatter(move |f| write!(f, "{file}:{line}")))
                 .map(display),

--- a/core/lib/tests/forward-includes-status-1560.rs
+++ b/core/lib/tests/forward-includes-status-1560.rs
@@ -7,9 +7,10 @@ struct Authenticated;
 
 #[rocket::async_trait]
 impl<'r> FromRequest<'r> for Authenticated {
+    type Forward = Status;
     type Error = Status;
 
-    async fn from_request(request: &'r Request<'_>) -> request::Outcome<Self, Self::Error> {
+    async fn from_request(request: &'r Request<'_>) -> request::Outcome<Self, Status, Status> {
         if request.headers().contains("Authenticated") {
             request::Outcome::Success(Authenticated)
         } else {
@@ -22,9 +23,10 @@ struct TeapotForward;
 
 #[rocket::async_trait]
 impl<'r> FromRequest<'r> for TeapotForward {
+    type Forward = Status;
     type Error = Status;
 
-    async fn from_request(_: &'r Request<'_>) -> request::Outcome<Self, Self::Error> {
+    async fn from_request(_: &'r Request<'_>) -> request::Outcome<Self, Status, Status> {
         request::Outcome::Forward(Status::ImATeapot)
     }
 }

--- a/core/lib/tests/forward-includes-status-1560.rs
+++ b/core/lib/tests/forward-includes-status-1560.rs
@@ -7,7 +7,7 @@ struct Authenticated;
 
 #[rocket::async_trait]
 impl<'r> FromRequest<'r> for Authenticated {
-    type Error = std::convert::Infallible;
+    type Error = Status;
 
     async fn from_request(request: &'r Request<'_>) -> request::Outcome<Self, Self::Error> {
         if request.headers().contains("Authenticated") {
@@ -22,7 +22,7 @@ struct TeapotForward;
 
 #[rocket::async_trait]
 impl<'r> FromRequest<'r> for TeapotForward {
-    type Error = std::convert::Infallible;
+    type Error = Status;
 
     async fn from_request(_: &'r Request<'_>) -> request::Outcome<Self, Self::Error> {
         request::Outcome::Forward(Status::ImATeapot)

--- a/core/lib/tests/local-request-content-type-issue-505.rs
+++ b/core/lib/tests/local-request-content-type-issue-505.rs
@@ -9,9 +9,9 @@ struct HasContentType;
 
 #[rocket::async_trait]
 impl<'r> FromRequest<'r> for HasContentType {
-    type Error = ();
+    type Error = Status;
 
-    async fn from_request(req: &'r Request<'_>) -> request::Outcome<Self, ()> {
+    async fn from_request(req: &'r Request<'_>) -> request::Outcome<Self, Self::Error> {
         req.content_type().map(|_| HasContentType).or_forward(Status::NotFound)
     }
 }
@@ -20,7 +20,7 @@ use rocket::data::{self, FromData};
 
 #[rocket::async_trait]
 impl<'r> FromData<'r> for HasContentType {
-    type Error = ();
+    type Error = Status;
 
     async fn from_data(req: &'r Request<'_>, data: Data<'r>) -> data::Outcome<'r, Self> {
         req.content_type().map(|_| HasContentType).or_forward((data, Status::NotFound))

--- a/core/lib/tests/local-request-content-type-issue-505.rs
+++ b/core/lib/tests/local-request-content-type-issue-505.rs
@@ -9,9 +9,10 @@ struct HasContentType;
 
 #[rocket::async_trait]
 impl<'r> FromRequest<'r> for HasContentType {
+    type Forward = Status;
     type Error = Status;
 
-    async fn from_request(req: &'r Request<'_>) -> request::Outcome<Self, Self::Error> {
+    async fn from_request(req: &'r Request<'_>) -> request::Outcome<Self, Status, Status> {
         req.content_type().map(|_| HasContentType).or_forward(Status::NotFound)
     }
 }

--- a/core/lib/tests/panic-handling.rs
+++ b/core/lib/tests/panic-handling.rs
@@ -4,6 +4,7 @@ use rocket::{Request, Rocket, Route, Catcher, Build, route, catcher};
 use rocket::data::Data;
 use rocket::http::{Method, Status};
 use rocket::local::blocking::Client;
+use rocket::catcher::TypedError;
 
 #[get("/panic")]
 fn panic_route() -> &'static str {
@@ -73,7 +74,11 @@ fn catches_early_route_panic() {
 
 #[test]
 fn catches_early_catcher_panic() {
-    fn pre_future_catcher<'r>(_: Status, _: &'r Request<'_>) -> catcher::BoxFuture<'r> {
+    fn pre_future_catcher<'r>(
+        _: Status,
+        _: &'r dyn TypedError<'r>,
+        _: &'r Request<'_>
+    ) -> catcher::BoxFuture<'r> {
         panic!("a panicking pre-future catcher")
     }
 

--- a/core/lib/tests/responder_lifetime-issue-345.rs
+++ b/core/lib/tests/responder_lifetime-issue-345.rs
@@ -13,7 +13,7 @@ pub struct CustomResponder<'r, R> {
 }
 
 impl<'r, 'o: 'r, R: Responder<'r, 'o>> Responder<'r, 'o> for CustomResponder<'r, R> {
-    fn respond_to(self, req: &'r Request<'_>) -> Result<'o> {
+    fn respond_to(self, req: &'r Request<'_>) -> Result<'r, 'o> {
         self.responder.respond_to(req)
     }
 }

--- a/core/lib/tests/sentinel.rs
+++ b/core/lib/tests/sentinel.rs
@@ -110,7 +110,7 @@ struct Data;
 
 #[crate::async_trait]
 impl<'r> data::FromData<'r> for Data {
-    type Error = Error;
+    type Error = std::io::Error;
     async fn from_data(_: &'r Request<'_>, _: data::Data<'r>) -> data::Outcome<'r, Self> {
         unimplemented!()
     }
@@ -151,10 +151,11 @@ fn inner_sentinels_detected() {
     #[derive(Responder)]
     struct MyThing<T>(T);
 
+    #[derive(TypedError)]
     struct ResponderSentinel;
 
     impl<'r, 'o: 'r> response::Responder<'r, 'o> for ResponderSentinel {
-        fn respond_to(self, _: &'r Request<'_>) -> response::Result<'o> {
+        fn respond_to(self, _: &'r Request<'_>) -> response::Result<'r, 'o> {
             unimplemented!()
         }
     }
@@ -171,7 +172,7 @@ fn inner_sentinels_detected() {
     let err = Client::debug_with(routes![route]).unwrap_err();
     assert!(matches!(err.kind(), SentinelAborts(vec) if vec.len() == 1));
 
-    #[derive(Responder)]
+    #[derive(Responder, TypedError)]
     struct Inner<T>(T);
 
     #[get("/")]

--- a/docs/guide/01-upgrading.md
+++ b/docs/guide/01-upgrading.md
@@ -6,6 +6,20 @@ summary = "a migration guide from Rocket v0.5 to v0.6"
 
 This a placeholder for an eventual migration guide from v0.5 to v0.6.
 
+## Typed Catchers
+
+The largest change from 0.5 to 0.6 is a complete overhaul of the error catching
+mechanism. While most catchers should continue to function as expected, the
+new functionality completely changes how errors should be handled.
+
+When forwarding or generating an error, every guard is required to provide a typed
+error. Previously, errors were forwarded to catchers based on the URI, format, and
+status code. Now, since every error has an associated typed error, catchers can
+specialize on the error type, and will even recieve access to the typed error
+when generating a response.
+
+<!-- TODO: Compelte notes with examples -->
+
 ## Getting Help
 
 If you run into any issues upgrading, we encourage you to ask questions via

--- a/docs/guide/02-quickstart.md
+++ b/docs/guide/02-quickstart.md
@@ -12,8 +12,9 @@ Started].
 ## Running Examples
 
 The absolute fastest way to start experimenting with Rocket is to clone the
-[Rocket repository](@github) and run the included examples in the `examples/`
-directory. For instance, the following set of commands runs the `hello` example:
+[Rocket repository](https://github.com/rwf2/Rocket) and run the included
+examples in the `examples/` directory. For instance, the following set of
+commands runs the `hello` example:
 
 ```sh
 git clone https://github.com/rwf2/Rocket

--- a/docs/guide/05-requests.md
+++ b/docs/guide/05-requests.md
@@ -2129,7 +2129,7 @@ it attempted to parse, a `FromParamError<'_, ParseBoolError>'` can be used.
 #[catch(400, error = "<error>")]
 fn bad_request(error: &FromParamError<'_, ParseBoolError>) {
   let raw_string_that_caused_error = error.raw;
-  let error_value = error.error;
+  let error_value = &error.error;
   /* .. */
 }
 ```

--- a/docs/guide/05-requests.md
+++ b/docs/guide/05-requests.md
@@ -557,6 +557,7 @@ dynamically:
 # #[macro_use] extern crate rocket;
 # fn main() {}
 
+# use rocket::either::Either;
 # type Template = ();
 # type AdminUser = rocket::http::Method;
 # type User = rocket::http::Method;
@@ -566,9 +567,11 @@ dynamically:
 use rocket::response::Redirect;
 
 #[get("/admin", rank = 2)]
-fn admin_panel_user(user: Option<User>) -> Result<&'static str, Redirect> {
-    let user = user.ok_or_else(|| Redirect::to(uri!(login)))?;
-    Ok("Sorry, you must be an administrator to access this page.")
+fn admin_panel_user(user: Option<User>) -> Either<&'static str, Redirect> {
+    match user {
+      Some(user) => Either::Left("Sorry, you must be an administrator to access this page."),
+      None => Either::Right(Redirect::to(uri!(login))),
+    }
 }
 ```
 

--- a/docs/guide/05-requests.md
+++ b/docs/guide/05-requests.md
@@ -547,7 +547,9 @@ it always succeeds. The user is redirected to a log in page.
 A failing or forwarding guard can be "caught" in handler, preventing it from
 failing or forwarding, via the `Option<T>` and `Result<T, E>` guards. When a
 guard `T` fails or forwards, `Option<T>` will be `None`. If a guard `T` fails
-with error `E`, `Result<T, E>` will be `Err(E)`.
+with error `E`, `Result<T, E>` will be `Err(E)`. If they are not caught by
+one of these mechanisms, the error will instead be passed to a matching
+catcher. See [Error Catchers](#error-catchers) for more information.
 
 As an example, for the `User` guard above, instead of allowing the guard to
 forward in `admin_panel_user`, we might want to detect it and handle it
@@ -2018,20 +2020,21 @@ Application processing is fallible. Errors arise from the following sources:
   * A routing failure.
 
 If any of these occur, Rocket returns an error to the client. To generate the
-error, Rocket invokes the _catcher_ corresponding to the error's status code and
+error, Rocket invokes the _catcher_ corresponding to the error's type, status code and
 scope. Catchers are similar to routes except in that:
 
   1. Catchers are only invoked on error conditions.
   2. Catchers are declared with the `catch` attribute.
   3. Catchers are _registered_ with [`register()`] instead of [`mount()`].
   4. Any modifications to cookies are cleared before a catcher is invoked.
-  5. Error catchers cannot invoke guards.
-  6. Error catchers should not fail to produce a response.
+  <!-- 5. Error catchers cannot invoke guards. -->
+  <!-- 6. Error catchers should not fail to produce a response. -->
   7. Catchers are scoped to a path prefix.
 
-To declare a catcher for a given status code, use the [`catch`] attribute, which
-takes a single integer corresponding to the HTTP status code to catch. For
-instance, to declare a catcher for `404 Not Found` errors, you'd write:
+To declare a simply catcher for a given status code, use the [`catch`]
+attribute, which takes a single integer corresponding to the HTTP status code
+to catch. For instance, to declare a catcher for `404 Not Found` errors, you'd
+write:
 
 ```rust
 # #[macro_use] extern crate rocket;
@@ -2043,10 +2046,16 @@ use rocket::Request;
 fn not_found(req: &Request) { /* .. */ }
 ```
 
-Catchers may take zero, one, or two arguments. If the catcher takes one
-argument, it must be of type [`&Request`]. It it takes two, they must be of type
-[`Status`] and [`&Request`], in that order. As with routes, the return type must
-implement `Responder`. A concrete implementation may look like:
+Catchers may take any number of arguments. These are error guards, which are a
+superset of request guards. This means that any request guard can be used to
+extract useful information from a request that caused the error. However, it's
+recommended to stick with infallible request guards, since catchers typically
+don't forward. If a request guard fails in a catcher, it's typically treated
+as a 500 error, reguardless of what the original error status was.
+
+In addition to request guards, there are a few other types that can be used as
+<!-- TODO: Links -->
+guards. Most prominently `&Request` actually can be used as an error guard.
 
 ```rust
 # #[macro_use] extern crate rocket;
@@ -2059,6 +2068,10 @@ fn not_found(req: &Request) -> String {
     format!("Sorry, '{}' is not a valid path.", req.uri())
 }
 ```
+
+<!-- TODO: Links -->
+There are a few other types, including `Status` and `&dyn TypedError`. The latter
+will be discussed in more detail below.
 
 Also as with routes, Rocket needs to know about a catcher before it is used to
 handle errors. The process, known as "registering" a catcher, is similar to
@@ -2076,6 +2089,77 @@ fn main() {
     rocket::build().register("/", catchers![not_found]);
 }
 ```
+
+### Typed catchers
+
+When a request guard (or any other guard) fails, it produces an error type
+that identifies what status code should be returned, and includes a set of
+useful information about the error, such as what caused it, or where the error
+occured. Rocket exposes a mechanism to retrieve this error type in catchers. The
+simplest option is to specialize a catcher for a specific error type. This can
+be done by adding a `error = "<error>"` parameter to the `#[catch]` attribute
+and a parameter to the function, much like the `data` parameter on a route. The
+parameter's type should be a reference to the error type you wish to handle in
+this catcher.
+
+For example, the following catcher will handle any error of the type `ParseBoolError`.
+
+```rust
+# #[macro_use] extern crate rocket;
+# use std::str::ParseBoolError;
+
+#[catch(400, error = "<error>")]
+fn bad_request(error: &ParseBoolError) { /* .. */ }
+```
+
+This error type is actually produced by `bool`'s `FromParam` or `FromFormField`
+implementation, and contains some information about why the value wasn't
+a valid boolean.
+
+In this specific case, the `ParseBoolError` doesn't contain a reference to
+the string that it failed to parse. To also get access to the string that
+<!-- TODO: links -->
+it attempted to parse, a `FromParamError<'_, ParseBoolError>'` can be used.
+
+```rust
+# #[macro_use] extern crate rocket;
+# use std::str::ParseBoolError;
+# use rocket::request::FromParamError;
+
+#[catch(400, error = "<error>")]
+fn bad_request(error: &FromParamError<'_, ParseBoolError>) {
+  let raw_string_that_caused_error = error.raw;
+  let error_value = error.error;
+  /* .. */
+}
+```
+
+This is a very general mechanism. For example, extending our previous authorization
+example, `AdminUser` and `User` could produce a specific error type, which, when caught,
+would render a page displaying the error. Because the error type is passed, we can easily
+display whether they were logged in, or they needed to have some additional permissions.
+
+However, to implement this, we must first discuss creating custom error types. Error types
+<!-- TODO: links -->
+must implement `TypedError`, which is a fairly complex trait. However, Rocket also exports
+a derive macro, that handles most of the complexities for you. This looks something like this:
+
+```rust
+# #[macro_use] extern crate rocket;
+#[derive(Debug, TypedError)]
+pub enum AuthorizationError {
+  #[error(status = 401)]
+  NotLoggedIn,
+  #[error(status = 401)]
+  NotEnoughPermissions,
+}
+```
+
+There are a number of additional options to the derive macro, however they are not documented
+<!-- TODO: links -->
+here. Read the documentation on the derive macro itself for more information.
+There are some additional complexities and limitations of the `TypedError`
+trait, which are likewise not discussed here.
 
 ### Scoping
 

--- a/docs/guide/06-responses.md
+++ b/docs/guide/06-responses.md
@@ -118,10 +118,10 @@ fn json() -> RawTeapotJson {
 ### Errors
 
 Responders may fail instead of generating a response by returning an `Err` with
-a status code. When this happens, Rocket forwards the request to the [error
-catcher](../requests/#error-catchers) for that status code.
+a typed error. When this happens, Rocket forwards the request to the [error
+catcher](../requests/#error-catchers) for that error type.
 
-If an error catcher has been registered for the given status code, Rocket will
+If an error catcher has been registered for the given type and code, Rocket will
 invoke it. The catcher creates and returns a response to the client. If no error
 catcher has been registered and the error status code is one of the standard
 HTTP status code, a default error catcher will be used. Default error catchers
@@ -129,11 +129,38 @@ return an HTML page with the status code and description. If there is no catcher
 for a custom status code, Rocket uses the **500** error catcher to return a
 response.
 
+
+### Result
+
+Result has a somewhat special implementation of Responder, designed to enable
+route handlers to directly return a typed error.
+
+```rust
+# #[macro_use] extern crate rocket;
+# fn main() {}
+
+#[derive(TypedError)]
+#[error(status = 400)]
+struct UnacceptablePath;
+
+#[get("/")]
+fn just_fail() -> Result<(), UnacceptablePath>  {
+    Err(UnacceptablePath)
+}
+```
+
+When combined with `rocket_db_pool` (or the sync variant), this can be incredibly
+powerful, since the database errors produced by both implement `TypedError`, and
+can directly be returned as an error from a handler. This makes handling database
+errors as simple as using the `?` operator, and writing a single catcher for
+the database errors.
+
 ### Status
 
 While not encouraged, you can also forward a request to a catcher manually by
-returning a [`Status`] directly. For instance, to forward to the catcher for
-**406: Not Acceptable**, you would write:
+returning a [`Status`] directly. We recommend using an existing (or a custom)
+typed error instead. For instance, to forward to the catcher for **406: Not
+Acceptable**, you would write:
 
 ```rust
 # #[macro_use] extern crate rocket;
@@ -348,7 +375,18 @@ async fn files(file: PathBuf) -> Result<NamedFile, NotFound<io::Error>> {
 }
 ```
 
-TODO: Typed: show catching mechanism here
+A catcher for the above error might look something like this.
+
+```rust
+# #[macro_use] extern crate rocket;
+# fn main() {}
+# use std::io;
+
+#[catch(404, error = "<io_error>")]
+fn handle_missing(io_error: &io::Error) {
+    /* ... */
+}
+```
 
 ## Rocket Responders
 

--- a/docs/guide/07-state.md
+++ b/docs/guide/07-state.md
@@ -136,9 +136,10 @@ struct Item<'r>(&'r str);
 
 #[rocket::async_trait]
 impl<'r> FromRequest<'r> for Item<'r> {
+    type Forward = Status;
     type Error = Status;
 
-    async fn from_request(request: &'r Request<'_>) -> request::Outcome<Self, Status> {
+    async fn from_request(request: &'r Request<'_>) -> request::Outcome<Self, Status, Status> {
         // Using `State` as a request guard. Use `inner()` to get an `'r`.
         let outcome = request.guard::<&State<MyConfig>>().await
             .map(|my_config| Item(&my_config.user_val));
@@ -188,9 +189,10 @@ struct RequestId(pub usize);
 /// Returns the current request's ID, assigning one only as necessary.
 #[rocket::async_trait]
 impl<'r> FromRequest<'r> for &'r RequestId {
+    type Forward = ();
     type Error = ();
 
-    async fn from_request(request: &'r Request<'_>) -> request::Outcome<Self, Self::Error> {
+    async fn from_request(request: &'r Request<'_>) -> request::Outcome<Self, Self::Error, Self::Forward> {
         // The closure passed to `local_cache` will be executed at most once per
         // request: the first time the `RequestId` guard is used. If it is
         // requested again, `local_cache` will return the same value.

--- a/docs/guide/07-state.md
+++ b/docs/guide/07-state.md
@@ -136,9 +136,9 @@ struct Item<'r>(&'r str);
 
 #[rocket::async_trait]
 impl<'r> FromRequest<'r> for Item<'r> {
-    type Error = ();
+    type Error = Status;
 
-    async fn from_request(request: &'r Request<'_>) -> request::Outcome<Self, ()> {
+    async fn from_request(request: &'r Request<'_>) -> request::Outcome<Self, Status> {
         // Using `State` as a request guard. Use `inner()` to get an `'r`.
         let outcome = request.guard::<&State<MyConfig>>().await
             .map(|my_config| Item(&my_config.user_val));

--- a/docs/guide/12-pastebin.md
+++ b/docs/guide/12-pastebin.md
@@ -367,7 +367,7 @@ use rocket::tokio::fs::File;
 #     pub fn new(size: usize) -> PasteId<'static> { todo!() }
 #     pub fn file_path(&self) -> PathBuf { todo!() }
 # }
-# #[derive(rocket::TypedError)]
+# #[derive(Debug, rocket::TypedError)]
 # pub struct InvalidPasteId;
 # impl<'a> FromParam<'a> for PasteId<'a> {
 #     type Error = InvalidPasteId;
@@ -446,7 +446,7 @@ pub struct PasteId<'a>(Cow<'a, str>);
 #     pub fn file_path(&self) -> PathBuf { todo!() }
 # }
 #
-# #[derive(rocket::TypedError)]
+# #[derive(Debug, rocket::TypedError)]
 # pub struct InvalidPasteId;
 # impl<'a> FromParam<'a> for PasteId<'a> {
 #     type Error = InvalidPasteId;

--- a/docs/guide/12-pastebin.md
+++ b/docs/guide/12-pastebin.md
@@ -326,16 +326,20 @@ Here's the `FromParam` implementation for `PasteId` in `src/paste_id.rs`:
 use rocket::request::FromParam;
 # use std::borrow::Cow;
 # pub struct PasteId<'a>(Cow<'a, str>);
+# use rocket::TypedError;
+
+#[derive(Debug, TypedError)]
+pub struct InvalidPasteId;
 
 /// Returns an instance of `PasteId` if the path segment is a valid ID.
-/// Otherwise returns the invalid ID as the `Err` value.
+/// Otherwise returns an `InvalidPasteId` as the error.
 impl<'a> FromParam<'a> for PasteId<'a> {
-    type Error = &'a str;
+    type Error = InvalidPasteId;
 
     fn from_param(param: &'a str) -> Result<Self, Self::Error> {
         param.chars().all(|c| c.is_ascii_alphanumeric())
             .then(|| PasteId(param.into()))
-            .ok_or(param)
+            .ok_or(InvalidPasteId)
     }
 }
 ```
@@ -363,8 +367,10 @@ use rocket::tokio::fs::File;
 #     pub fn new(size: usize) -> PasteId<'static> { todo!() }
 #     pub fn file_path(&self) -> PathBuf { todo!() }
 # }
+# #[derive(rocket::TypedError)]
+# pub struct InvalidPasteId;
 # impl<'a> FromParam<'a> for PasteId<'a> {
-#     type Error = &'a str;
+#     type Error = InvalidPasteId;
 #     fn from_param(param: &'a str) -> Result<Self, Self::Error> { todo!() }
 # }
 
@@ -440,8 +446,10 @@ pub struct PasteId<'a>(Cow<'a, str>);
 #     pub fn file_path(&self) -> PathBuf { todo!() }
 # }
 #
+# #[derive(rocket::TypedError)]
+# pub struct InvalidPasteId;
 # impl<'a> FromParam<'a> for PasteId<'a> {
-#     type Error = &'a str;
+#     type Error = InvalidPasteId;
 #     fn from_param(param: &'a str) -> Result<Self, Self::Error> { todo!() }
 # }
 // We implement the `upload` route in `main.rs`:

--- a/docs/guide/12-pastebin.md
+++ b/docs/guide/12-pastebin.md
@@ -184,7 +184,7 @@ Before we continue, we'll need to make a few design decisions.
             let mut id = String::with_capacity(size);
             let mut rng = rand::thread_rng();
             for _ in 0..size {
-                id.push(BASE62[rng.gen::<usize>() % 62] as char);
+                id.push(BASE62[rng.gen::<usize>() % BASE62.len()] as char);
             }
 
             PasteId(Cow::Owned(id))

--- a/docs/guide/14-faq.md
+++ b/docs/guide/14-faq.md
@@ -466,6 +466,8 @@ create methods to do several wraps, simplifying handlers.
 
 ```rust
 # use rocket::response::Responder;
+# use rocket::serde::json::Json;
+# type Error = &'static str;
 use rocket::fs::NamedFile;
 use rocket::http::ContentType;
 

--- a/docs/guide/14-faq.md
+++ b/docs/guide/14-faq.md
@@ -420,7 +420,7 @@ use rocket::response::{self, Response, Responder};
 use rocket::serde::json::Json;
 
 impl<'r> Responder<'r, 'static> for Person {
-    fn respond_to(self, req: &'r Request<'_>) -> response::Result<'static> {
+    fn respond_to(self, req: &'r Request<'_>) -> response::Result<'r, 'static> {
         Response::build_from(Json(&self).respond_to(req)?)
             .raw_header("X-Person-Name", self.name)
             .raw_header("X-Person-Age", self.age.to_string())

--- a/docs/guide/14-faq.md
+++ b/docs/guide/14-faq.md
@@ -440,8 +440,7 @@ impl<'r> Responder<'r, 'static> for Person {
 How do I make one handler return different responses or status codes?
 {{ answer() }}
 
-If you're returning _two_ different responses, use a `Result<T, E>` or an
-[`Either<A, B>`].
+If you're returning _two_ different responses, use an [`Either<A, B>`].
 
 If you need to return _more_ than two kinds, [derive a custom `Responder`] `enum`:
 
@@ -458,6 +457,32 @@ enum Error<'r, T> {
     NotFound(NamedFile),
     #[response(status = 500)]
     A(&'r str, ContentType),
+}
+```
+
+In many cases, it may still be better to use a custom responder for just two
+types, since the derive makes it easy to specify types, and you can easily
+create methods to do several wraps, simplifying handlers.
+
+```rust
+# use rocket::response::Responder;
+use rocket::fs::NamedFile;
+use rocket::http::ContentType;
+
+#[derive(Responder)]
+enum ApiResponse<T> {
+    #[response(status = 400)]
+    BadRequest(Json<Error>),
+    Success(Json<T>),
+}
+
+impl<T> ApiResponse<T> {
+  pub fn bad_request(error: Error) -> Self {
+    Self::BadRequest(Json(error))
+  }
+  pub fn sucess(val: T) -> Self {
+    Self::Success(Json(val))
+  }
 }
 ```
 

--- a/examples/cookies/src/session.rs
+++ b/examples/cookies/src/session.rs
@@ -3,6 +3,7 @@ use rocket::request::{self, FlashMessage, FromRequest, Request};
 use rocket::response::{Redirect, Flash};
 use rocket::http::{CookieJar, Status};
 use rocket::form::Form;
+use rocket::either::Either;
 
 use rocket_dyn_templates::{Template, context};
 
@@ -17,7 +18,7 @@ struct User(usize);
 
 #[rocket::async_trait]
 impl<'r> FromRequest<'r> for User {
-    type Error = std::convert::Infallible;
+    type Error = Status;
 
     async fn from_request(request: &'r Request<'_>) -> request::Outcome<User, Self::Error> {
         request.cookies()
@@ -58,12 +59,12 @@ fn login_page(flash: Option<FlashMessage<'_>>) -> Template {
 }
 
 #[post("/login", data = "<login>")]
-fn post_login(jar: &CookieJar<'_>, login: Form<Login<'_>>) -> Result<Redirect, Flash<Redirect>> {
+fn post_login(jar: &CookieJar<'_>, login: Form<Login<'_>>) -> Either<Redirect, Flash<Redirect>> {
     if login.username == "Sergio" && login.password == "password" {
         jar.add_private(("user_id", "1"));
-        Ok(Redirect::to(uri!(index)))
+        Either::Left(Redirect::to(uri!(index)))
     } else {
-        Err(Flash::error(Redirect::to(uri!(login_page)), "Invalid username/password."))
+        Either::Right(Flash::error(Redirect::to(uri!(login_page)), "Invalid username/password."))
     }
 }
 

--- a/examples/cookies/src/session.rs
+++ b/examples/cookies/src/session.rs
@@ -18,9 +18,12 @@ struct User(usize);
 
 #[rocket::async_trait]
 impl<'r> FromRequest<'r> for User {
+    type Forward = Status;
     type Error = Status;
 
-    async fn from_request(request: &'r Request<'_>) -> request::Outcome<User, Self::Error> {
+    async fn from_request(request: &'r Request<'_>) ->
+        request::Outcome<User, Self::Error, Self::Forward>
+    {
         request.cookies()
             .get_private("user_id")
             .and_then(|cookie| cookie.value().parse().ok())

--- a/examples/cookies/src/session.rs
+++ b/examples/cookies/src/session.rs
@@ -3,7 +3,7 @@ use rocket::request::{self, FlashMessage, FromRequest, Request};
 use rocket::response::{Redirect, Flash};
 use rocket::http::{CookieJar, Status};
 use rocket::form::Form;
-use rocket::either::Either;
+use rocket::either::{Either, Left, Right};
 
 use rocket_dyn_templates::{Template, context};
 
@@ -62,9 +62,9 @@ fn login_page(flash: Option<FlashMessage<'_>>) -> Template {
 fn post_login(jar: &CookieJar<'_>, login: Form<Login<'_>>) -> Either<Redirect, Flash<Redirect>> {
     if login.username == "Sergio" && login.password == "password" {
         jar.add_private(("user_id", "1"));
-        Either::Left(Redirect::to(uri!(index)))
+        Left(Redirect::to(uri!(index)))
     } else {
-        Either::Right(Flash::error(Redirect::to(uri!(login_page)), "Invalid username/password."))
+        Right(Flash::error(Redirect::to(uri!(login_page)), "Invalid username/password."))
     }
 }
 

--- a/examples/error-handling/Cargo.toml
+++ b/examples/error-handling/Cargo.toml
@@ -7,4 +7,3 @@ publish = false
 
 [dependencies]
 rocket = { path = "../../core/lib", features = ["json"] }
-transient = { path = "/code/matthew/transient" }

--- a/examples/error-handling/Cargo.toml
+++ b/examples/error-handling/Cargo.toml
@@ -6,4 +6,5 @@ edition = "2021"
 publish = false
 
 [dependencies]
-rocket = { path = "../../core/lib" }
+rocket = { path = "../../core/lib", features = ["json"] }
+transient = { path = "/code/matthew/transient" }

--- a/examples/error-handling/src/tests.rs
+++ b/examples/error-handling/src/tests.rs
@@ -75,8 +75,6 @@ fn test_hello_invalid_age() {
 fn test_hello_sergio() {
     let client = Client::tracked(super::rocket()).unwrap();
 
-    // TODO: typed: This logic has changed, either needs to be fixed
-    // or this test changed.
     for path in &["oops", "-129"] {
         let request = client.get(format!("/hello/Sergio/{}", path));
         let expected = super::sergio_error();

--- a/examples/error-handling/src/tests.rs
+++ b/examples/error-handling/src/tests.rs
@@ -1,5 +1,6 @@
 use rocket::local::blocking::Client;
 use rocket::http::Status;
+use rocket::serde::json::to_string as json_string;
 
 #[test]
 fn test_hello() {
@@ -24,19 +25,19 @@ fn forced_error() {
     assert_eq!(response.into_string().unwrap(), expected.0);
 
     let request = client.get("/405");
-    let expected = super::default_catcher(Status::MethodNotAllowed, request.inner());
+    let expected = super::default_catcher(Status::MethodNotAllowed, request.uri());
     let response = request.dispatch();
     assert_eq!(response.status(), Status::MethodNotAllowed);
     assert_eq!(response.into_string().unwrap(), expected.1);
 
     let request = client.get("/533");
-    let expected = super::default_catcher(Status::new(533), request.inner());
+    let expected = super::default_catcher(Status::new(533), request.uri());
     let response = request.dispatch();
     assert_eq!(response.status(), Status::new(533));
     assert_eq!(response.into_string().unwrap(), expected.1);
 
     let request = client.get("/700");
-    let expected = super::default_catcher(Status::InternalServerError, request.inner());
+    let expected = super::default_catcher(Status::InternalServerError, request.uri());
     let response = request.dispatch();
     assert_eq!(response.status(), Status::InternalServerError);
     assert_eq!(response.into_string().unwrap(), expected.1);
@@ -48,16 +49,22 @@ fn test_hello_invalid_age() {
 
     for path in &["Ford/-129", "Trillian/128"] {
         let request = client.get(format!("/hello/{}", path));
-        let expected = super::default_catcher(Status::UnprocessableEntity, request.inner());
+        let expected = super::ErrorInfo {
+            invalid_value: path.split_once("/").unwrap().1,
+            description: format!(
+                "{}",
+                path.split_once("/").unwrap().1.parse::<i8>().unwrap_err()
+            ),
+        };
         let response = request.dispatch();
         assert_eq!(response.status(), Status::UnprocessableEntity);
-        assert_eq!(response.into_string().unwrap(), expected.1);
+        assert_eq!(response.into_string().unwrap(), json_string(&expected).unwrap());
     }
 
     {
         let path = &"foo/bar/baz";
         let request = client.get(format!("/hello/{}", path));
-        let expected = super::hello_not_found(request.inner());
+        let expected = super::hello_not_found(request.uri());
         let response = request.dispatch();
         assert_eq!(response.status(), Status::NotFound);
         assert_eq!(response.into_string().unwrap(), expected.0);
@@ -68,6 +75,8 @@ fn test_hello_invalid_age() {
 fn test_hello_sergio() {
     let client = Client::tracked(super::rocket()).unwrap();
 
+    // TODO: typed: This logic has changed, either needs to be fixed
+    // or this test changed.
     for path in &["oops", "-129"] {
         let request = client.get(format!("/hello/Sergio/{}", path));
         let expected = super::sergio_error();

--- a/examples/manual-routing/src/main.rs
+++ b/examples/manual-routing/src/main.rs
@@ -63,7 +63,11 @@ fn get_upload<'r>(req: &'r Request, _: Data<'r>) -> route::BoxFuture<'r> {
     route::Outcome::from(req, std::fs::File::open(path).ok()).pin()
 }
 
-fn not_found_handler<'r>(_: Status, _: &'r dyn TypedError<'r>, req: &'r Request) -> catcher::BoxFuture<'r> {
+fn not_found_handler<'r>(
+    _: Status,
+    _: &'r dyn TypedError<'r>,
+    req: &'r Request,
+) -> catcher::BoxFuture<'r> {
     let responder = Custom(Status::NotFound, format!("Couldn't find: {}", req.uri()));
     Box::pin(async move { responder.respond_to(req).map_err(|e| e.status()) })
 }

--- a/examples/pastebin/src/paste_id.rs
+++ b/examples/pastebin/src/paste_id.rs
@@ -32,14 +32,18 @@ impl PasteId<'_> {
     }
 }
 
+#[derive(Debug, TypedError)]
+#[error(debug)]
+pub struct InvalidId<'a>(pub &'a str);
+
 /// Returns an instance of `PasteId` if the path segment is a valid ID.
 /// Otherwise returns the invalid ID as the `Err` value.
 impl<'a> FromParam<'a> for PasteId<'a> {
-    type Error = &'a str;
+    type Error = InvalidId<'a>;
 
     fn from_param(param: &'a str) -> Result<Self, Self::Error> {
         param.chars().all(|c| c.is_ascii_alphanumeric())
             .then(|| PasteId(param.into()))
-            .ok_or(param)
+            .ok_or(InvalidId(param))
     }
 }

--- a/examples/pastebin/src/paste_id.rs
+++ b/examples/pastebin/src/paste_id.rs
@@ -34,16 +34,16 @@ impl PasteId<'_> {
 
 #[derive(Debug, TypedError)]
 #[error(debug)]
-pub struct InvalidId<'a>(pub &'a str);
+pub struct InvalidId;
 
 /// Returns an instance of `PasteId` if the path segment is a valid ID.
 /// Otherwise returns the invalid ID as the `Err` value.
 impl<'a> FromParam<'a> for PasteId<'a> {
-    type Error = InvalidId<'a>;
+    type Error = InvalidId;
 
     fn from_param(param: &'a str) -> Result<Self, Self::Error> {
         param.chars().all(|c| c.is_ascii_alphanumeric())
             .then(|| PasteId(param.into()))
-            .ok_or(InvalidId(param))
+            .ok_or(InvalidId)
     }
 }

--- a/examples/responders/src/main.rs
+++ b/examples/responders/src/main.rs
@@ -113,10 +113,10 @@ fn redir_login() -> &'static str {
 }
 
 #[get("/redir/<name>")]
-fn maybe_redir(name: &str) -> Result<&'static str, Redirect> {
+fn maybe_redir(name: &str) -> Either<&'static str, Redirect> {
     match name {
-        "Sergio" => Ok("Hello, Sergio!"),
-        _ => Err(Redirect::to(uri!(redir_login))),
+        "Sergio" => Either::Left("Hello, Sergio!"),
+        _ => Either::Right(Redirect::to(uri!(redir_login))),
     }
 }
 

--- a/examples/responders/src/main.rs
+++ b/examples/responders/src/main.rs
@@ -115,8 +115,8 @@ fn redir_login() -> &'static str {
 #[get("/redir/<name>")]
 fn maybe_redir(name: &str) -> Either<&'static str, Redirect> {
     match name {
-        "Sergio" => Either::Left("Hello, Sergio!"),
-        _ => Either::Right(Redirect::to(uri!(redir_login))),
+        "Sergio" => Left("Hello, Sergio!"),
+        _ => Right(Redirect::to(uri!(redir_login))),
     }
 }
 
@@ -159,7 +159,7 @@ fn not_found(request: &Request<'_>) -> content::RawHtml<String> {
 
 /******************************* `Either` Responder ***************************/
 
-use rocket::either::Either;
+use rocket::either::{Either, Left, Right};
 use rocket::response::content::{RawJson, RawMsgPack};
 use rocket::http::uncased::AsUncased;
 
@@ -169,9 +169,9 @@ use rocket::http::uncased::AsUncased;
 #[get("/content/<kind>")]
 fn json_or_msgpack(kind: &str) -> Either<RawJson<&'static str>, RawMsgPack<&'static [u8]>> {
     if kind.as_uncased() == "msgpack" {
-        Either::Right(RawMsgPack(&[162, 104, 105]))
+        Right(RawMsgPack(&[162, 104, 105]))
     } else {
-        Either::Left(RawJson("\"hi\""))
+        Left(RawJson("\"hi\""))
     }
 }
 

--- a/examples/serialization/src/tests.rs
+++ b/examples/serialization/src/tests.rs
@@ -38,7 +38,9 @@ fn json_bad_get_put() {
 
     // Try to put a message without a proper body.
     let res = client.put("/json/80").header(ContentType::JSON).dispatch();
-    assert_eq!(res.status(), Status::BadRequest);
+    // TODO: Typed: This behavior has changed
+    assert_eq!(res.status(), Status::UnprocessableEntity);
+        // Status::BadRequest);
 
     // Try to put a message with a semantically invalid body.
     let res = client.put("/json/0")

--- a/examples/serialization/src/tests.rs
+++ b/examples/serialization/src/tests.rs
@@ -38,9 +38,7 @@ fn json_bad_get_put() {
 
     // Try to put a message without a proper body.
     let res = client.put("/json/80").header(ContentType::JSON).dispatch();
-    // TODO: Typed: This behavior has changed
     assert_eq!(res.status(), Status::UnprocessableEntity);
-        // Status::BadRequest);
 
     // Try to put a message with a semantically invalid body.
     let res = client.put("/json/0")

--- a/examples/serialization/src/uuid.rs
+++ b/examples/serialization/src/uuid.rs
@@ -8,10 +8,10 @@ use rocket::serde::uuid::Uuid;
 struct People(HashMap<Uuid, &'static str>);
 
 #[get("/people/<id>")]
-fn people(id: Uuid, people: &State<People>) -> Result<String, String> {
+fn people(id: Uuid, people: &State<People>) -> String {
     people.0.get(&id)
         .map(|person| format!("We found: {}", person))
-        .ok_or_else(|| format!("Missing person for UUID: {}", id))
+        .unwrap_or_else(|| format!("Missing person for UUID: {}", id))
 }
 
 pub fn stage() -> rocket::fairing::AdHoc {

--- a/examples/state/src/request_local.rs
+++ b/examples/state/src/request_local.rs
@@ -1,4 +1,5 @@
 use std::sync::atomic::{AtomicUsize, Ordering};
+use std::convert::Infallible;
 
 use rocket::{State, StateError};
 use rocket::outcome::{Outcome, try_outcome};
@@ -18,9 +19,12 @@ struct Guard4;
 
 #[rocket::async_trait]
 impl<'r> FromRequest<'r> for Guard1 {
+    type Forward = Infallible;
     type Error = StateError;
 
-    async fn from_request(req: &'r Request<'_>) -> request::Outcome<Self, Self::Error> {
+    async fn from_request(req: &'r Request<'_>) ->
+        request::Outcome<Self, Self::Error, Self::Forward>
+    {
         let atomics = try_outcome!(req.guard::<&State<Atomics>>().await);
         atomics.uncached.fetch_add(1, Ordering::Relaxed);
         req.local_cache(|| {
@@ -33,9 +37,12 @@ impl<'r> FromRequest<'r> for Guard1 {
 
 #[rocket::async_trait]
 impl<'r> FromRequest<'r> for Guard2 {
+    type Forward = Infallible;
     type Error = StateError;
 
-    async fn from_request(req: &'r Request<'_>) -> request::Outcome<Self, Self::Error> {
+    async fn from_request(req: &'r Request<'_>) ->
+        request::Outcome<Self, Self::Error, Self::Forward>
+    {
         try_outcome!(req.guard::<Guard1>().await);
         Outcome::Success(Guard2)
     }
@@ -43,9 +50,12 @@ impl<'r> FromRequest<'r> for Guard2 {
 
 #[rocket::async_trait]
 impl<'r> FromRequest<'r> for Guard3 {
+    type Forward = Infallible;
     type Error = StateError;
 
-    async fn from_request(req: &'r Request<'_>) -> request::Outcome<Self, Self::Error> {
+    async fn from_request(req: &'r Request<'_>) ->
+        request::Outcome<Self, Self::Error, Self::Forward>
+    {
         let atomics = try_outcome!(req.guard::<&State<Atomics>>().await);
         atomics.uncached.fetch_add(1, Ordering::Relaxed);
         req.local_cache_async(async {
@@ -58,9 +68,12 @@ impl<'r> FromRequest<'r> for Guard3 {
 
 #[rocket::async_trait]
 impl<'r> FromRequest<'r> for Guard4 {
+    type Forward = Infallible;
     type Error = StateError;
 
-    async fn from_request(req: &'r Request<'_>) -> request::Outcome<Self, Self::Error> {
+    async fn from_request(req: &'r Request<'_>) ->
+        request::Outcome<Self, Self::Error, Self::Forward>
+    {
         try_outcome!(Guard3::from_request(req).await);
         Outcome::Success(Guard4)
     }

--- a/examples/state/src/request_local.rs
+++ b/examples/state/src/request_local.rs
@@ -1,6 +1,6 @@
 use std::sync::atomic::{AtomicUsize, Ordering};
 
-use rocket::{State, StateMissing};
+use rocket::{State, StateError};
 use rocket::outcome::{Outcome, try_outcome};
 use rocket::request::{self, FromRequest, Request};
 use rocket::fairing::AdHoc;
@@ -18,7 +18,7 @@ struct Guard4;
 
 #[rocket::async_trait]
 impl<'r> FromRequest<'r> for Guard1 {
-    type Error = StateMissing;
+    type Error = StateError;
 
     async fn from_request(req: &'r Request<'_>) -> request::Outcome<Self, Self::Error> {
         let atomics = try_outcome!(req.guard::<&State<Atomics>>().await);
@@ -33,7 +33,7 @@ impl<'r> FromRequest<'r> for Guard1 {
 
 #[rocket::async_trait]
 impl<'r> FromRequest<'r> for Guard2 {
-    type Error = StateMissing;
+    type Error = StateError;
 
     async fn from_request(req: &'r Request<'_>) -> request::Outcome<Self, Self::Error> {
         try_outcome!(req.guard::<Guard1>().await);
@@ -43,7 +43,7 @@ impl<'r> FromRequest<'r> for Guard2 {
 
 #[rocket::async_trait]
 impl<'r> FromRequest<'r> for Guard3 {
-    type Error = StateMissing;
+    type Error = StateError;
 
     async fn from_request(req: &'r Request<'_>) -> request::Outcome<Self, Self::Error> {
         let atomics = try_outcome!(req.guard::<&State<Atomics>>().await);
@@ -58,7 +58,7 @@ impl<'r> FromRequest<'r> for Guard3 {
 
 #[rocket::async_trait]
 impl<'r> FromRequest<'r> for Guard4 {
-    type Error = StateMissing;
+    type Error = StateError;
 
     async fn from_request(req: &'r Request<'_>) -> request::Outcome<Self, Self::Error> {
         try_outcome!(Guard3::from_request(req).await);

--- a/examples/tls/Cargo.toml
+++ b/examples/tls/Cargo.toml
@@ -7,6 +7,7 @@ publish = false
 
 [dependencies]
 rocket = { path = "../../core/lib", features = ["tls", "mtls", "secrets", "http3-preview"] }
+tracing = "*"
 yansi = "1.0.1"
 
 [target.'cfg(unix)'.dependencies]

--- a/examples/tls/Cargo.toml
+++ b/examples/tls/Cargo.toml
@@ -7,7 +7,6 @@ publish = false
 
 [dependencies]
 rocket = { path = "../../core/lib", features = ["tls", "mtls", "secrets", "http3-preview"] }
-tracing = "*"
 yansi = "1.0.1"
 
 [target.'cfg(unix)'.dependencies]

--- a/examples/todo/src/main.rs
+++ b/examples/todo/src/main.rs
@@ -70,7 +70,9 @@ async fn toggle(id: i32, conn: DbConn) -> Either<Redirect, Template> {
         Ok(_) => Either::Left(Redirect::to("/")),
         Err(e) => {
             error!("DB toggle({id}) error: {e}");
-            Either::Right(Template::render("index", Context::err(&conn, "Failed to toggle task.").await))
+            Either::Right(
+                Template::render("index", Context::err(&conn, "Failed to toggle task.").await)
+            )
         }
     }
 }
@@ -81,7 +83,9 @@ async fn delete(id: i32, conn: DbConn) -> Either<Flash<Redirect>, Template> {
         Ok(_) => Either::Left(Flash::success(Redirect::to("/"), "Todo was deleted.")),
         Err(e) => {
             error!("DB deletion({id}) error: {e}");
-            Either::Right(Template::render("index", Context::err(&conn, "Failed to delete task.").await))
+            Either::Right(
+                Template::render("index", Context::err(&conn, "Failed to delete task.").await)
+            )
         }
     }
 }

--- a/examples/todo/src/main.rs
+++ b/examples/todo/src/main.rs
@@ -13,6 +13,7 @@ use rocket::response::{Flash, Redirect};
 use rocket::serde::Serialize;
 use rocket::form::Form;
 use rocket::fs::{FileServer, relative};
+use rocket::either::Either;
 
 use rocket_dyn_templates::Template;
 
@@ -64,23 +65,23 @@ async fn new(todo_form: Form<Todo>, conn: DbConn) -> Flash<Redirect> {
 }
 
 #[put("/<id>")]
-async fn toggle(id: i32, conn: DbConn) -> Result<Redirect, Template> {
+async fn toggle(id: i32, conn: DbConn) -> Either<Redirect, Template> {
     match Task::toggle_with_id(id, &conn).await {
-        Ok(_) => Ok(Redirect::to("/")),
+        Ok(_) => Either::Left(Redirect::to("/")),
         Err(e) => {
             error!("DB toggle({id}) error: {e}");
-            Err(Template::render("index", Context::err(&conn, "Failed to toggle task.").await))
+            Either::Right(Template::render("index", Context::err(&conn, "Failed to toggle task.").await))
         }
     }
 }
 
 #[delete("/<id>")]
-async fn delete(id: i32, conn: DbConn) -> Result<Flash<Redirect>, Template> {
+async fn delete(id: i32, conn: DbConn) -> Either<Flash<Redirect>, Template> {
     match Task::delete_with_id(id, &conn).await {
-        Ok(_) => Ok(Flash::success(Redirect::to("/"), "Todo was deleted.")),
+        Ok(_) => Either::Left(Flash::success(Redirect::to("/"), "Todo was deleted.")),
         Err(e) => {
             error!("DB deletion({id}) error: {e}");
-            Err(Template::render("index", Context::err(&conn, "Failed to delete task.").await))
+            Either::Right(Template::render("index", Context::err(&conn, "Failed to delete task.").await))
         }
     }
 }

--- a/examples/todo/src/main.rs
+++ b/examples/todo/src/main.rs
@@ -13,7 +13,7 @@ use rocket::response::{Flash, Redirect};
 use rocket::serde::Serialize;
 use rocket::form::Form;
 use rocket::fs::{FileServer, relative};
-use rocket::either::Either;
+use rocket::either::{Either, Left, Right};
 
 use rocket_dyn_templates::Template;
 
@@ -67,12 +67,10 @@ async fn new(todo_form: Form<Todo>, conn: DbConn) -> Flash<Redirect> {
 #[put("/<id>")]
 async fn toggle(id: i32, conn: DbConn) -> Either<Redirect, Template> {
     match Task::toggle_with_id(id, &conn).await {
-        Ok(_) => Either::Left(Redirect::to("/")),
+        Ok(_) => Left(Redirect::to("/")),
         Err(e) => {
             error!("DB toggle({id}) error: {e}");
-            Either::Right(
-                Template::render("index", Context::err(&conn, "Failed to toggle task.").await)
-            )
+            Right(Template::render("index", Context::err(&conn, "Failed to toggle task.").await))
         }
     }
 }
@@ -80,12 +78,10 @@ async fn toggle(id: i32, conn: DbConn) -> Either<Redirect, Template> {
 #[delete("/<id>")]
 async fn delete(id: i32, conn: DbConn) -> Either<Flash<Redirect>, Template> {
     match Task::delete_with_id(id, &conn).await {
-        Ok(_) => Either::Left(Flash::success(Redirect::to("/"), "Todo was deleted.")),
+        Ok(_) => Left(Flash::success(Redirect::to("/"), "Todo was deleted.")),
         Err(e) => {
             error!("DB deletion({id}) error: {e}");
-            Either::Right(
-                Template::render("index", Context::err(&conn, "Failed to delete task.").await)
-            )
+            Right(Template::render("index", Context::err(&conn, "Failed to delete task.").await))
         }
     }
 }

--- a/scripts/mk-docs.sh
+++ b/scripts/mk-docs.sh
@@ -25,7 +25,7 @@ pushd "${PROJECT_ROOT}" > /dev/null 2>&1
       --crate-version ${DOC_VERSION} \
       --enable-index-page \
       --generate-link-to-definition" \
-      cargo doc -Zrustdoc-map --no-deps --all-features \
+      cargo +nightly doc -Zrustdoc-map --no-deps --all-features \
         -p rocket \
         -p rocket_db_pools \
         -p rocket_sync_db_pools \

--- a/testbench/src/servers/tracing.rs
+++ b/testbench/src/servers/tracing.rs
@@ -33,16 +33,22 @@ impl FromParam<'_> for UseDebug {
 
 #[rocket::async_trait]
 impl<'r> FromRequest<'r> for UseDisplay {
+    type Forward = Self;
     type Error = Self;
-    async fn from_request(_: &'r Request<'_>) -> request::Outcome<Self, Self::Error> {
+    async fn from_request(_: &'r Request<'_>) ->
+        request::Outcome<Self, Self::Error, Self::Forward>
+    {
         request::Outcome::Error(Self("req"))
     }
 }
 
 #[rocket::async_trait]
 impl<'r> FromRequest<'r> for UseDebug {
+    type Forward = Self;
     type Error = Self;
-    async fn from_request(_: &'r Request<'_>) -> request::Outcome<Self, Self::Error> {
+    async fn from_request(_: &'r Request<'_>) ->
+        request::Outcome<Self, Self::Error, Self::Forward>
+    {
         request::Outcome::Error(Self)
     }
 }

--- a/testbench/src/servers/tracing.rs
+++ b/testbench/src/servers/tracing.rs
@@ -3,17 +3,16 @@
 
 use std::fmt;
 
-use rocket::http::Status;
 use rocket::data::{self, FromData};
 use rocket::http::uri::{Segments, fmt::Path};
 use rocket::request::{self, FromParam, FromRequest, FromSegments};
 
 use crate::prelude::*;
 
-#[derive(Debug)]
+#[derive(Debug, TypedError)]
 struct UseDisplay(&'static str);
 
-#[derive(Debug)]
+#[derive(Debug, TypedError)]
 struct UseDebug;
 
 impl fmt::Display for UseDisplay {
@@ -36,7 +35,7 @@ impl FromParam<'_> for UseDebug {
 impl<'r> FromRequest<'r> for UseDisplay {
     type Error = Self;
     async fn from_request(_: &'r Request<'_>) -> request::Outcome<Self, Self::Error> {
-        request::Outcome::Error((Status::InternalServerError, Self("req")))
+        request::Outcome::Error(Self("req"))
     }
 }
 
@@ -44,7 +43,7 @@ impl<'r> FromRequest<'r> for UseDisplay {
 impl<'r> FromRequest<'r> for UseDebug {
     type Error = Self;
     async fn from_request(_: &'r Request<'_>) -> request::Outcome<Self, Self::Error> {
-        request::Outcome::Error((Status::InternalServerError, Self))
+        request::Outcome::Error(Self)
     }
 }
 
@@ -52,7 +51,7 @@ impl<'r> FromRequest<'r> for UseDebug {
 impl<'r> FromData<'r> for UseDisplay {
     type Error = Self;
     async fn from_data(_: &'r Request<'_>, _: Data<'r>) -> data::Outcome<'r, Self> {
-        data::Outcome::Error((Status::InternalServerError, Self("data")))
+        data::Outcome::Error(Self("data"))
     }
 }
 
@@ -60,7 +59,7 @@ impl<'r> FromData<'r> for UseDisplay {
 impl<'r> FromData<'r> for UseDebug {
     type Error = Self;
     async fn from_data(_: &'r Request<'_>, _: Data<'r>) -> data::Outcome<'r, Self> {
-        data::Outcome::Error((Status::InternalServerError, Self))
+        data::Outcome::Error(Self)
     }
 }
 


### PR DESCRIPTION
Addresses #749, adds support for typed catchers via the `transient` crate.

When a `FromRequest`, `FromParam`, `FromQuery`, or `FromData` implementation returns an `Error` or `Forward`, if the returned error implements `Any<Co<'r>>`, it is boxed and travels with the `Outcome`.

A catcher can have a third parameter, now `(&E, Status, &Request)`, where `E` is some type that implements `Any<Co<'r>>`. If the error contained in the `Outcome` is of the same type, it is downcast to
the specific type, and passed to the catcher.

A working example can be seen in the `error-handling` example - simply visit `/hello/name/a` to see a `ParseIntError` returned by the `FromParam` of `i8`.

# TODO

- [x] Better syntax for passing the error type to catchers. This is likely going to look like a new `FromError` trait, and a `error = "<error>"` parameter for the upcast error.
  - [x] Requires new compile tests
- [x] Catchers should carry an `Option<TypeId>`, and use it to prevent false collisions.
  - [x] Update matcher code to also check `TypeId`
- [x] Special `TypedError` trait
- [x] `Responder` should return an `Outcome<..., Self::Error, ...>`
- [x] Improve example error message
- [x] `Any<Co<'r>>` should be `Any<Inv<'r>>`. Transient actually already protects us from casting `Any<Inv<'r>>` to a different `Any<Inv<'l>>`, by telling the compiler that `Inv<'a>` is invariant wrt `'a`.
- [x] Documentation needs to be written - this is a pretty big change, and somewhat difficult to use. There are a number of small gotchas - from types that don't implement `Transient`, to simply using the wrong error type in the catcher. I'm not sure what the right way to present this is.
- [x] We should consider logging or carrying the error type's name, to help users identify what the type is, and why their catcher doesn't catch it. (Also log if the type implements `Transient`, since many types don't).
  - [x] Tests (likely using a tracing subscriber) should validate this (I'm not sure how, since `type_name` isn't a stable name - nevermind, it is, since the test is compiled with the same version).
- [x] Export a `TypedError` derive macro.
  - [x] I'm current involved with @JRRudy1 in working on an improved derive macro, which would be safe to use.
  - [x] Also derive a `Transient` implementation at the same time.
- [x] `rocket::form::Errors` (and it's parts) should implement Transient. (Now non-issue)
- [x] `FromError` trait
- [x] Fairings should be able to reject requests (and include a `TypedError`)
- [x] Clean up TODOs
- [x] Contrib
  - [x] dyn_templates: The responder and fairing impls need to be updated.
  - [x] (sync_)db_pools: The error types should implement `TypedError`.
  - [x] ws: The error types should implement `TypedError`, and responder/fairing impls need to be updated.