### PR TITLE
Drop Rocket inside the tokio async context when using launch

### DIFF
--- a/core/codegen/src/attribute/entry/launch.rs
+++ b/core/codegen/src/attribute/entry/launch.rs
@@ -113,7 +113,9 @@ impl EntryAttr for Launch {
             #[allow(dead_code)] #f
 
             #vis #sig {
-                #_error::Error::report(::rocket::async_main(#launch))
+                ::rocket::async_main(async move {
+                    #_error::Error::report(#launch.await)
+                })
             }
         ))
     }


### PR DESCRIPTION
Moves error printing and the implicit drop inside the tokio runtime when using the `#[launch]` attribute.

Based on an issue reported on Element. See https://matrix.to/#/!kDIcCXWSVfdahNCJWq:mozilla.org/$2CSzlNC4rQw7Wd7Y7L2fV-2_fTxsvq93elL1foVfQ1s?via=mozilla.org&via=matrix.org&via=catgirl.cloud.

Basically, the Rocket instance gets dropped (after a successful shutdown or a `Shutdown` error) outside the tokio runtime. Some minor restructuring of the generated code ensures the tokio context outlives Rocket, if only slightly.