### PR TITLE
Update rocket_ws dep to pick up security fix.

### DIFF
--- a/contrib/ws/Cargo.toml
+++ b/contrib/ws/Cargo.toml
@@ -20,7 +20,7 @@ default = ["tungstenite"]
 tungstenite = ["tokio-tungstenite"]
 
 [dependencies]
-tokio-tungstenite = { version = "0.21", optional = true }
+tokio-tungstenite = { version = "0.23.1", optional = true }
 
 [dependencies.rocket]
 version = "0.6.0-dev"


### PR DESCRIPTION
This may not be needed...   
This is the CVE that was reported in our code scans: https://nvd.nist.gov/vuln/detail/CVE-2023-43669

Rocket is already above that version, but our scans are still complaining.
I'm investigating, but will leave this open in case you just want to bump your deps.