### PR TITLE
Update mongodb integration to use version 3

### DIFF
--- a/contrib/db_pools/lib/Cargo.toml
+++ b/contrib/db_pools/lib/Cargo.toml
@@ -65,9 +65,9 @@ features = ["rt_tokio_1"]
 optional = true
 
 [dependencies.mongodb]
-version = "2"
+version = "3"
 default-features = false
-features = ["tokio-runtime"]
+features = ["compat-3-0-0", "rustls-tls"]
 optional = true
 
 [dependencies.diesel-async]

--- a/contrib/db_pools/lib/src/lib.rs
+++ b/contrib/db_pools/lib/src/lib.rs
@@ -131,7 +131,7 @@
 //! On shutdown, new connections are denied. Shutdown waits for connections to
 //! be returned.
 //!
-//! ## `mongodb` (v2)
+//! ## `mongodb` (v3)
 //!
 //! | Database | Feature   | [`Pool`] Type and [`Connection`] Deref |
 //! |----------|-----------|----------------------------------------|


### PR DESCRIPTION
This updates the optional `mongodb` database support to use version 3 of the client crate.