### PR TITLE
`Option` guards should return `None` only if the value is empty.

### DIFF
--- a/core/lib/src/request/from_param.rs
+++ b/core/lib/src/request/from_param.rs
@@ -294,17 +294,17 @@ impl<'a, T: FromParam<'a>> FromParam<'a> for Result<T, T::Error> {
     }
 }
 
-impl<'a, T: FromParam<'a>> FromParam<'a> for Option<T> {
-    type Error = std::convert::Infallible;
+// impl<'a, T: FromParam<'a>> FromParam<'a> for Option<T> {
+//     type Error = std::convert::Infallible;
 
-    #[inline]
-    fn from_param(param: &'a str) -> Result<Self, Self::Error> {
-        match T::from_param(param) {
-            Ok(val) => Ok(Some(val)),
-            Err(_) => Ok(None)
-        }
-    }
-}
+//     #[inline]
+//     fn from_param(param: &'a str) -> Result<Self, Self::Error> {
+//         match T::from_param(param) {
+//             Ok(val) => Ok(Some(val)),
+//             Err(_) => Ok(None)
+//         }
+//     }
+// }
 
 /// Trait to convert _many_ dynamic path segment strings to a concrete value.
 ///
@@ -379,13 +379,14 @@ impl<'r, T: FromSegments<'r>> FromSegments<'r> for Result<T, T::Error> {
 }
 
 impl<'r, T: FromSegments<'r>> FromSegments<'r> for Option<T> {
-    type Error = std::convert::Infallible;
+    type Error = T::Error;
 
     #[inline]
     fn from_segments(segments: Segments<'r, Path>) -> Result<Option<T>, Self::Error> {
-        match T::from_segments(segments) {
-            Ok(val) => Ok(Some(val)),
-            Err(_) => Ok(None)
+        if segments.is_empty() {
+            Ok(None)
+        } else {
+            T::from_segments(segments).map(Some)
         }
     }
 }


### PR DESCRIPTION
Based on #2543

Option is usable as pretty much any kind of guard. Right now, it's always infallible, and simply ignored errors. This may be somewhat counter-intuitive for newcomers (and old hats such as myself), and may have some other negative implications. This PR changes the behavior of `Option` to match what one might expect - `None` represents the empty case, as it makes sense for each type of guard.

## The Negative Implications

There are a couple of issues I can see with the current behavior. First, and most obvious, it's likely not what a newcomer to Rocket would expect. We should avoid sweeping errors under the rug, so to speak, and instead leave that choice fully up to the user. Second, there may be a non-trivial overhead to simply discarding data in the case we fail to parse. This is generally mitigated by data limits, but I don't think they represent a full solution. Finally, the current behavior may actually impede debugging efforts. To see how, consider the following route:

```rust
#[get("/?<age>")]
fn r(age: Option<u8>) -> ...
```

Right now, a request to `/?age=a` will call `r(None)` - with no mention (even in the logs) that the guard failed. With this PR, the above request will instead return an Error (which, with typed-catchers, could produce a nice error message for the consumer). This makes it much easier to work with APIs with optional parameters, since they won't just silently ignore parsing errors.

# New behavior

In general, the old behavior can be emulated by using `Result`, and ignoring the `Err` value. We could provide a separate `Option`-like enum that had the old behavior, but it might be easier to simply provide a set of type aliases that fill in the error type automatically, e.g. `type DataResult<T: FromData> = Result<T, T::Error>;`

## FromData

`FromData` now uses `peek` to check whether the data contains any bytes. Iff it is empty, it will succeed with `None`.

## FromParam

This implementation has been removed. This is a more obviously breaking change, but since Rocket ignores empty segments, we can't meaningfully provide this implementation anymore.

## FromSegements

This implementation now only succeeds with `None` if the `Segments` is empty.

## FromForm

This one has different behavior depending on the current strictness. In strict mode, it succeeds with `None` iff there were no values passed to the `FromForm` implementation. Otherwise, it also succeeds with `None` if all the `ErrorKind`s were `Missing`.

## FromRequest

This one has not been altered. There isn't really an easy way to check whether a request guard failed or was simply missing, but it may be reasonable to change this to only catch `Forwards`. In this case, the old behavior can be emulated by `Option<Result>`, (or `Result<Option>`).

# TODO

- [ ] Update documentation
  - [ ] FromData
  - [ ] FromParam
  - [ ] FromSegments
  - [ ] FromForm
  - [ ] FromRequest
- [ ] FromRequest implementation
