### PR TITLE
Fix wrong URL in guide (configuration)

### DIFF
--- a/docs/guide/10-configuration.md
+++ b/docs/guide/10-configuration.md
@@ -607,4 +607,4 @@ or `APP_` environment variables, Rocket will make use of them. The application
 can also extract its configuration, done here via the `Adhoc::config()` fairing.
 
 [`rocket::custom()`]: @api/master/rocket/fn.custom.html
-[`rocket::build()`]: @api/master/rocket/fn.custom.html
+[`rocket::build()`]: @api/master/rocket/fn.build.html


### PR DESCRIPTION
Found a URL that was going to the wrong place. This should fix it.