### PR TITLE
Improve `http::Status` by implementing traits via derive macro.

### DIFF
--- a/core/http/src/status.rs
+++ b/core/http/src/status.rs
@@ -112,7 +112,7 @@ impl StatusClass {
 /// }
 /// # }
 /// ```
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct Status {
     /// The HTTP status code associated with this status.
     pub code: u16,
@@ -351,32 +351,6 @@ impl fmt::Display for Status {
     #[inline(always)]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{} {}", self.code, self.reason_lossy())
-    }
-}
-
-impl std::hash::Hash for Status {
-    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        self.code.hash(state)
-    }
-}
-
-impl PartialEq for Status {
-    fn eq(&self, other: &Self) -> bool {
-        self.code.eq(&other.code)
-    }
-}
-
-impl Eq for Status { }
-
-impl PartialOrd for Status {
-    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        Some(self.cmp(other))
-    }
-}
-
-impl Ord for Status {
-    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
-        self.code.cmp(&other.code)
     }
 }
 


### PR DESCRIPTION
# Main Reasoning

`PartialEq` when not implemented via derive macro, lacks `StructuralPartialEq`. 

It causes undesired side effect, that the compiler rejects 
constants like `Status::Unauthorized` to be used in pattern 
(for example in the `match` expression)

# Solution

Because the current manual implementation is trivial and matches
derived code 1:1, we can replace it with `#[derive]` without
changes in the behaviour

Fixes #2844