### PR TITLE
Update Cargo.toml

### DIFF
--- a/contrib/sync_db_pools/lib/Cargo.toml
+++ b/contrib/sync_db_pools/lib/Cargo.toml
@@ -23,7 +23,7 @@ r2d2 = "0.8"
 tokio = { version = "1.6.1", features = ["rt", "rt-multi-thread"] }
 serde = { version = "1.0", features = ["derive"] }
 
-diesel = { version = "2.0.0", default-features = false, optional = true }
+diesel = { version = "2.2.3", default-features = false, optional = true }
 
 postgres = { version = "0.19", optional = true }
 r2d2_postgres = { version = "0.18", optional = true }


### PR DESCRIPTION
Bumps the dependency to at least 2.2.3 as per the advisory

[Advisory](https://rustsec.org/advisories/RUSTSEC-2024-0365.html)

(even though this crate may not be using the function mentioned in the advisory, it is better to bump it to ensure that there is no chance of other dependencies pulling it)