### PR TITLE
Fix minor typos in guide and docstring

### DIFF
--- a/core/lib/src/sentinel.rs
+++ b/core/lib/src/sentinel.rs
@@ -159,7 +159,7 @@ use crate::{Rocket, Ignite};
 ///
 /// **Note:** _Rocket actively discourages using `impl Trait` in route
 /// signatures. In addition to impeding sentinel discovery, doing so decreases
-/// the ability to gleam a handler's functionality based on its type signature._
+/// the ability to glean a handler's functionality based on its type signature._
 ///
 /// The return type of the route `f` depends on its implementation. At present,
 /// it is not possible to name the underlying concrete type of an `impl Trait`

--- a/docs/guide/05-requests.md
+++ b/docs/guide/05-requests.md
@@ -876,7 +876,7 @@ use rocket::data::{Data, ToByteUnit};
 
 #[post("/debug", data = "<data>")]
 async fn debug(data: Data<'_>) -> std::io::Result<()> {
-    // Stream at most 512KiB all of the body data to stdout.
+    // Stream at most 512KiB of the body data to stdout.
     data.open(512.kibibytes())
         .stream_to(tokio::io::stdout())
         .await?;

--- a/docs/guide/10-configuration.md
+++ b/docs/guide/10-configuration.md
@@ -6,7 +6,7 @@ summary = "overview and customization of Rocket application configuration"
 
 Rocket's configuration system is flexible. Based on [Figment](@figment), it
 allows you to configure your application the way _you_ want while also providing
-with a sensible set of defaults.
+a sensible set of defaults.
 
 ## Overview
 


### PR DESCRIPTION
Just some things I noticed while reading through the docs.