### PR TITLE
Fix contrib package versions

### DIFF
--- a/contrib/db_pools/README.md
+++ b/contrib/db_pools/README.md
@@ -17,7 +17,7 @@ full usage details.
 
    ```toml
    [dependencies.rocket_db_pools]
-   version = "0.1.0"
+   version = "0.2.0"
    features = ["sqlx_sqlite"]
    ```
 

--- a/contrib/db_pools/codegen/Cargo.toml
+++ b/contrib/db_pools/codegen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocket_db_pools_codegen"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Sergio Benitez <sb@sergio.bz>", "Jeb Rosen <jeb@jebrosen.com>"]
 description = "Procedural macros for rocket_db_pools."
 repository = "https://github.com/rwf2/Rocket/tree/master/contrib/db_pools"

--- a/contrib/db_pools/lib/Cargo.toml
+++ b/contrib/db_pools/lib/Cargo.toml
@@ -37,7 +37,7 @@ default-features = false
 
 [dependencies.rocket_db_pools_codegen]
 path = "../codegen"
-version = "0.1.0"
+version = "0.2.0"
 
 [dependencies.deadpool]
 version = "0.12.1"

--- a/contrib/db_pools/lib/Cargo.toml
+++ b/contrib/db_pools/lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocket_db_pools"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Sergio Benitez <sb@sergio.bz>", "Jeb Rosen <jeb@jebrosen.com>"]
 description = "Rocket async database pooling support"
 repository = "https://github.com/rwf2/Rocket/tree/master/contrib/db_pools"

--- a/contrib/db_pools/lib/src/diesel.rs
+++ b/contrib/db_pools/lib/src/diesel.rs
@@ -12,7 +12,7 @@
 //! diesel = "2"
 //!
 //! [dependencies.rocket_db_pools]
-//! version = "0.1.0"
+//! version = "0.2.0"
 //! features = ["diesel_mysql"]
 //! ```
 //!

--- a/contrib/db_pools/lib/src/lib.rs
+++ b/contrib/db_pools/lib/src/lib.rs
@@ -7,7 +7,7 @@
 //!
 //!    ```toml
 //!    [dependencies.rocket_db_pools]
-//!    version = "0.1.0"
+//!    version = "0.2.0"
 //!    features = ["sqlx_sqlite"]
 //!    ```
 //!
@@ -165,7 +165,7 @@
 //! features = ["macros", "migrate"]
 //!
 //! [dependencies.rocket_db_pools]
-//! version = "0.1.0"
+//! version = "0.2.0"
 //! features = ["sqlx_sqlite"]
 //! ```
 //!

--- a/contrib/dyn_templates/Cargo.toml
+++ b/contrib/dyn_templates/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocket_dyn_templates"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Sergio Benitez <sb@sergio.bz>"]
 description = "Dynamic templating engine integration for Rocket."
 documentation = "https://api.rocket.rs/master/rocket_dyn_templates/"

--- a/contrib/dyn_templates/README.md
+++ b/contrib/dyn_templates/README.md
@@ -22,7 +22,7 @@ and automatically reloads templates when compiled in debug mode. It supports [Ha
 
      ```toml
      [dependencies.rocket_dyn_templates]
-     version = "0.1.0"
+     version = "0.2.0"
      features = ["handlebars", "tera", "minijinja"]
      ```
 

--- a/contrib/dyn_templates/src/lib.rs
+++ b/contrib/dyn_templates/src/lib.rs
@@ -12,7 +12,7 @@
 //!
 //!      ```toml
 //!      [dependencies.rocket_dyn_templates]
-//!      version = "0.1.0"
+//!      version = "0.2.0"
 //!      features = ["handlebars", "tera", "minijinja"]
 //!      ```
 //!

--- a/contrib/ws/Cargo.toml
+++ b/contrib/ws/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocket_ws"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Sergio Benitez <sb@sergio.bz>"]
 description = "WebSocket support for Rocket."
 documentation = "https://api.rocket.rs/master/rocket_ws/"

--- a/contrib/ws/README.md
+++ b/contrib/ws/README.md
@@ -16,7 +16,7 @@ This crate provides WebSocket support for Rocket via integration with Rocket's
 
      ```toml
      [dependencies]
-     ws = { package = "rocket_ws", version = "0.1.0" }
+     ws = { package = "rocket_ws", version = "0.1.1" }
      ```
 
    2. Use it!

--- a/contrib/ws/src/lib.rs
+++ b/contrib/ws/src/lib.rs
@@ -10,7 +10,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! ws = { package = "rocket_ws", version = "0.1.0" }
+//! ws = { package = "rocket_ws", version = "0.1.1" }
 //! ```
 //!
 //! Then, use [`WebSocket`] as a request guard in any route and either call

--- a/docs/guide/07-state.md
+++ b/docs/guide/07-state.md
@@ -236,7 +236,7 @@ in three simple steps:
 
    ```toml
    [dependencies.rocket_db_pools]
-   version = "0.1.0"
+   version = "0.2.0"
    features = ["sqlx_sqlite"]
    ```
 
@@ -304,7 +304,7 @@ default-features = false
 features = ["macros", "migrate"]
 
 [dependencies.rocket_db_pools]
-version = "0.1.0"
+version = "0.2.0"
 features = ["sqlx_sqlite"]
 ```
 


### PR DESCRIPTION
Hello,

I just noticed that the version numbers of some `contrib` packages on the `master` branch are older than the latest versions actually released on on crates.io, while the `v0.5` branch already has the correct values.

I understand that the `master` branch contains unpublished changes (like dependencies etc.), but I was a bit confused by these relapse differences when reading the code at a glance 😅

## Changes

To catch up with the latest versions, I've updated the values in each `Cargo.toml` (and also docs/guide, doc comments and each `README.md`, according to the changes in the `v0.5` branch) as follows:

| contrib | version |
|---|---|
| rocket_db_pools | `0.1.0` -> [0.2.0](https://crates.io/crates/rocket_db_pools/versions) |
| rocket_db_pools_codegen | `0.1.0` -> [0.2.0](https://crates.io/crates/rocket_db_pools_codegen/versions) |
| rocket_dyn_templates | `0.1.0` -> [0.2.0](https://crates.io/crates/rocket_dyn_templates/versions) |
| rocket_ws | `0.1.0` -> [0.1.1](https://crates.io/crates/rocket_ws/versions) |

When the next version (`0.6`?) is released, these values perhaps may be different. But until then, I hope these changes make sense and avoid any misunderstanding 🙆🏽‍♀️ 