### PR TITLE
Fix Dockerfile example in "Deploying" chapter

### DIFF
--- a/docs/guide/11-deploying.md
+++ b/docs/guide/11-deploying.md
@@ -262,9 +262,9 @@ WORKDIR /app
 COPY --from=build /build/main ./
 
 ## copy runtime assets which may or may not exist
-COPY --from=build /build/Rocket.tom[l] ./static
-COPY --from=build /build/stati[c] ./static
-COPY --from=build /build/template[s] ./templates
+COPY --from=build /build/Rocket.tom[l] ./
+COPY --from=build /build/stati[c] ./static/
+COPY --from=build /build/template[s] ./templates/
 
 ## ensure the container listens globally on port 8080
 ENV ROCKET_ADDRESS=0.0.0.0


### PR DESCRIPTION
This now matches the layout of a typical project, instead of erroring out.