### PR TITLE
Add 'Request::version()' to return `hyper` version (non-local)

### DIFF
--- a/core/lib/src/http/mod.rs
+++ b/core/lib/src/http/mod.rs
@@ -3,6 +3,8 @@
 //! This module exports types that map to HTTP concepts or to the underlying
 //! HTTP library when needed.
 
+pub use hyper::Version;
+
 mod cookies;
 
 #[doc(inline)]

--- a/core/lib/src/lib.rs
+++ b/core/lib/src/lib.rs
@@ -165,6 +165,8 @@ mod router;
 mod phase;
 mod erased;
 
+pub use hyper::Version;
+
 #[doc(inline)] pub use rocket_codegen::*;
 
 #[doc(inline)] pub use crate::response::Response;


### PR DESCRIPTION
Adds a method (`Request::version()`) to return the hyper version of the request.

It is optional so that local clients don't need to deal with it. It seemed like overkill to add the extra arg to all the local client request methods. I'm not sure how to deal with an example or test for this unless you end up wanting to expose it to the local clients, but I don't know if it makes sense to in that context.