### PR TITLE
Remove unknown rust_analyzer cfg

### DIFF
--- a/core/codegen/src/attribute/async_bound/mod.rs
+++ b/core/codegen/src/attribute/async_bound/mod.rs
@@ -15,7 +15,6 @@ fn _async_bound(
     }
 
     let mut func: TraitItemFn = syn::parse(input)?;
-    let original: TraitItemFn = func.clone();
     if func.sig.asyncness.is_none() {
         let diag = Span::call_site()
             .error("attribute can only be applied to async fns")
@@ -43,14 +42,7 @@ fn _async_bound(
     };
 
     Ok(quote! {
-        #[cfg(all(not(doc), rust_analyzer))]
-        #original
-
-        #[cfg(all(doc, not(rust_analyzer)))]
         #doc
-        #original
-
-        #[cfg(not(any(doc, rust_analyzer)))]
         #func
     })
 }


### PR DESCRIPTION
From some basic testing, I cannot identify what advantage this provides. I assume this was a workaround for a bug in rust_analyzer, but I cannot identify what it might be.

@SergioBenitez
