### PR TITLE
Introduce diesel_sqlite feature (for rocket_db_pools support)

### DIFF
--- a/contrib/db_pools/lib/Cargo.toml
+++ b/contrib/db_pools/lib/Cargo.toml
@@ -28,6 +28,7 @@ sqlx_macros = ["sqlx/macros"]
 # diesel features
 diesel_postgres = ["diesel-async/postgres", "diesel-async/deadpool", "deadpool", "diesel"]
 diesel_mysql = ["diesel-async/mysql", "diesel-async/deadpool", "deadpool", "diesel"]
+diesel_sqlite = ["diesel-async/sqlite", "diesel-async/deadpool", "deadpool", "diesel"]
 # implicit features: mongodb
 
 [dependencies.rocket]

--- a/contrib/db_pools/lib/src/diesel.rs
+++ b/contrib/db_pools/lib/src/diesel.rs
@@ -95,6 +95,10 @@ pub use diesel_async::AsyncMysqlConnection;
 #[cfg(feature = "diesel_postgres")]
 pub use diesel_async::AsyncPgConnection;
 
+#[doc(inline)]
+#[cfg(feature = "diesel_sqlite")]
+pub use diesel_async::sync_connection_wrapper::SyncConnectionWrapper;
+
 /// Alias of a `Result` with an error type of [`Debug`] for a `diesel::Error`.
 ///
 /// `QueryResult` is a [`Responder`](rocket::response::Responder) when `T` (the
@@ -150,3 +154,25 @@ pub type MysqlPool = Pool<AsyncMysqlConnection>;
 /// ```
 #[cfg(feature = "diesel_postgres")]
 pub type PgPool = Pool<AsyncPgConnection>;
+
+/// Type alias for an `async` pool of Sqlite connections for `async` [diesel].
+///
+/// ```rust
+/// # extern crate rocket;
+/// # #[cfg(feature = "diesel_sqlite")] {
+/// # use rocket::get;
+/// use rocket_db_pools::{Database, Connection};
+/// use rocket_db_pools::diesel::{SqlitePool, prelude::*};
+///
+/// #[derive(Database)]
+/// #[database("my_sqlite_db_name")]
+/// struct Db(SqlitePool);
+///
+/// #[get("/")]
+/// async fn use_db(mut db: Connection<Db>) {
+///     /* .. */
+/// }
+/// # }
+/// ```
+#[cfg(feature = "diesel_sqlite")]
+pub type SqlitePool = Pool<SyncConnectionWrapper<SqliteConnection>>;

--- a/contrib/db_pools/lib/src/lib.rs
+++ b/contrib/db_pools/lib/src/lib.rs
@@ -141,10 +141,11 @@
 //!
 //! ## `diesel` (v2)
 //!
-//! | Database | Feature           | [`Pool`] Type         | [`Connection`] Deref             |
-//! |----------|-------------------|-----------------------|----------------------------------|
-//! | Postgres | `diesel_postgres` | [`diesel::PgPool`]    | [`diesel::AsyncPgConnection`]    |
-//! | MySQL    | `diesel_mysql`    | [`diesel::MysqlPool`] | [`diesel::AsyncMysqlConnection`] | //!
+//! | Database | Feature           | [`Pool`] Type          | [`Connection`] Deref                                         |
+//! |----------|-------------------|------------------------|--------------------------------------------------------------|
+//! | Postgres | `diesel_postgres` | [`diesel::PgPool`]     | [`diesel::AsyncPgConnection`]                                |
+//! | MySQL    | `diesel_mysql`    | [`diesel::MysqlPool`]  | [`diesel::AsyncMysqlConnection`]                             |
+//! | SQLite   | `diesel_sqlite`   | [`diesel::SqlitePool`] | [`diesel::SyncConnectionWrapper<diesel::SqliteConnection>>`] |
 //!
 //! See [`diesel`] for usage details.
 //!
@@ -243,7 +244,11 @@ pub use rocket;
 #[doc(inline)]
 pub use rocket::figment;
 
-#[cfg(any(feature = "diesel_postgres", feature = "diesel_mysql"))] pub mod diesel;
+#[cfg(any(
+    feature = "diesel_postgres",
+    feature = "diesel_mysql",
+    feature = "diesel_sqlite"
+))] pub mod diesel;
 #[cfg(feature = "deadpool_postgres")] pub use deadpool_postgres;
 #[cfg(feature = "deadpool_redis")] pub use deadpool_redis;
 #[cfg(feature = "mongodb")] pub use mongodb;

--- a/contrib/db_pools/lib/src/pool.rs
+++ b/contrib/db_pools/lib/src/pool.rs
@@ -192,6 +192,15 @@ mod deadpool_postgres {
         }
     }
 
+    #[cfg(feature = "diesel_sqlite")]
+    impl DeadManager for AsyncDieselConnectionManager<
+        diesel_async::sync_connection_wrapper::SyncConnectionWrapper::<diesel::SqliteConnection>
+    > {
+        fn new(config: &Config) -> Result<Self, Self::Error> {
+            Ok(Self::new(config.url.as_str()))
+        }
+    }
+
     #[rocket::async_trait]
     impl<M: DeadManager, C: From<Object<M>>> crate::Pool for Pool<M, C>
         where M::Type: Send, C: Send + Sync + 'static, M::Error: std::error::Error


### PR DESCRIPTION
Attempt at #2967 . I am pretty uncertain about this and I do not yet know how to test this (aside from the basic smoke test in the PR— see below).

I ran `./scripts/test.sh --contrib` as requested in the testing guide. It failed because of #2969. diesel.rs has three tests in it for MysqlPool, PgPool, and (now) SqlitePool, but it appears only the Mysql test is run. I don't know if this is because of #2969 or some other reason.