### PR TITLE
Minor doc fix: Change misleading sample code in rocket_ws

### DIFF
--- a/contrib/ws/src/lib.rs
+++ b/contrib/ws/src/lib.rs
@@ -15,13 +15,13 @@
 //!
 //! Then, use [`WebSocket`] as a request guard in any route and either call
 //! [`WebSocket::channel()`] or return a stream via [`Stream!`] or
-//! [`WebSocket::stream()`] in the handler. The examples below are equivalent:
+//! [`WebSocket::stream()`] in the handler. The endpoints in the example below are equivalent:
 //!
 //! ```rust
 //! # use rocket::get;
 //! # use rocket_ws as ws;
 //! #
-//! #[get("/echo?channel")]
+//! #[get("/echo/channel")]
 //! fn echo_channel(ws: ws::WebSocket) -> ws::Channel<'static> {
 //!     use rocket::futures::{SinkExt, StreamExt};
 //!
@@ -34,7 +34,7 @@
 //!     }))
 //! }
 //!
-//! #[get("/echo?stream")]
+//! #[get("/echo/stream")]
 //! fn echo_stream(ws: ws::WebSocket) -> ws::Stream!['static] {
 //!     ws::Stream! { ws =>
 //!         for await message in ws {
@@ -43,7 +43,7 @@
 //!     }
 //! }
 //!
-//! #[get("/echo?compose")]
+//! #[get("/echo/compose")]
 //! fn echo_compose(ws: ws::WebSocket) -> ws::Stream!['static] {
 //!     ws.stream(|io| io)
 //! }

--- a/contrib/ws/src/websocket.rs
+++ b/contrib/ws/src/websocket.rs
@@ -134,7 +134,7 @@ impl WebSocket {
     /// # use rocket_ws as ws;
     ///
     /// // Use `Stream!`, which internally calls `WebSocket::stream()`.
-    /// #[get("/echo?stream")]
+    /// #[get("/echo/stream")]
     /// fn echo_stream(ws: ws::WebSocket) -> ws::Stream!['static] {
     ///     ws::Stream! { ws =>
     ///         for await message in ws {
@@ -144,7 +144,7 @@ impl WebSocket {
     /// }
     ///
     /// // Use a raw stream.
-    /// #[get("/echo?compose")]
+    /// #[get("/echo/compose")]
     /// fn echo_compose(ws: ws::WebSocket) -> ws::Stream!['static] {
     ///     ws.stream(|io| io)
     /// }


### PR DESCRIPTION
Check out

https://api.rocket.rs/master/rocket_ws/

It offers three variants of a single function, at the addresses `#[get("/echo?channel")]`, `#[get("/echo?stream")]` and `#[get("/echo?compose")]`. In this case, the `?` is only a discriminator; accessing `/echo` with this sample code directly will give you a 404.

However, using `?` in this case is potentially confusing, and did confuse me. I wrote a small app copypasting the `channel` example and left in the `?channel`, assuming it to be "`<macro>` magic" (as is common in Rocket) and required, and then my app did not work, returning 404s when I queried it, because I'd written the route like `#[get("/chat?channel")]` and then queried it like `http://localhost/chat`.

**Expected behavior / change in patch**

I think you should change the `?`s to `/`s to prevent confusion, and make it clear the intent is one example with three routes rather than three copies of the same example with one route.

Note: It might be an experienced Rocket user would have immediately identified the meaning of the `?channel` syntax, but first-contact docs probably should not assume you are an experienced Rocket user.