### PR TITLE
Update diesel and diesel-async to newest versions

### DIFF
--- a/contrib/db_pools/lib/Cargo.toml
+++ b/contrib/db_pools/lib/Cargo.toml
@@ -28,6 +28,7 @@ sqlx_macros = ["sqlx/macros"]
 # diesel features
 diesel_postgres = ["diesel-async/postgres", "diesel-async/deadpool", "deadpool", "diesel"]
 diesel_mysql = ["diesel-async/mysql", "diesel-async/deadpool", "deadpool", "diesel"]
+diesel_sqlite = ["diesel-async/sqlite", "diesel-async/deadpool", "deadpool", "diesel"]
 # implicit features: mongodb
 
 [dependencies.rocket]

--- a/contrib/db_pools/lib/Cargo.toml
+++ b/contrib/db_pools/lib/Cargo.toml
@@ -41,7 +41,7 @@ path = "../codegen"
 version = "0.1.0"
 
 [dependencies.deadpool]
-version = "0.12.1"
+version = "0.13"
 default-features = false
 features = ["rt_tokio_1", "managed"]
 optional = true
@@ -65,13 +65,13 @@ features = ["compat-3-0-0", "rustls-tls"]
 optional = true
 
 [dependencies.diesel-async]
-version = "0.6.0"
+version = "0.9.2"
 default-features = false
 features = ["async-connection-wrapper"]
 optional = true
 
 [dependencies.diesel]
-version = "2.1"
+version = "2.3.12"
 default-features = false
 optional = true
 

--- a/contrib/db_pools/lib/src/diesel.rs
+++ b/contrib/db_pools/lib/src/diesel.rs
@@ -95,6 +95,10 @@ pub use diesel_async::AsyncMysqlConnection;
 #[cfg(feature = "diesel_postgres")]
 pub use diesel_async::AsyncPgConnection;
 
+#[doc(inline)]
+#[cfg(feature = "diesel_sqlite")]
+pub use diesel_async::sync_connection_wrapper::SyncConnectionWrapper;
+
 /// Alias of a `Result` with an error type of [`Debug`] for a `diesel::Error`.
 ///
 /// `QueryResult` is a [`Responder`](rocket::response::Responder) when `T` (the
@@ -150,3 +154,25 @@ pub type MysqlPool = Pool<AsyncMysqlConnection>;
 /// ```
 #[cfg(feature = "diesel_postgres")]
 pub type PgPool = Pool<AsyncPgConnection>;
+
+/// Type alias for an `async` pool of Sqlite connections for `async` [diesel].
+///
+/// ```rust
+/// # extern crate rocket;
+/// # #[cfg(feature = "diesel_sqlite")] {
+/// # use rocket::get;
+/// use rocket_db_pools::{Database, Connection};
+/// use rocket_db_pools::diesel::{SqlitePool, prelude::*};
+///
+/// #[derive(Database)]
+/// #[database("my_sqlite_db_name")]
+/// struct Db(SqlitePool);
+///
+/// #[get("/")]
+/// async fn use_db(mut db: Connection<Db>) {
+///     /* .. */
+/// }
+/// # }
+/// ```
+#[cfg(feature = "diesel_sqlite")]
+pub type SqlitePool = Pool<SyncConnectionWrapper<SqliteConnection>>;

--- a/contrib/db_pools/lib/src/lib.rs
+++ b/contrib/db_pools/lib/src/lib.rs
@@ -141,10 +141,11 @@
 //!
 //! ## `diesel` (v2)
 //!
-//! | Database | Feature           | [`Pool`] Type         | [`Connection`] Deref             |
-//! |----------|-------------------|-----------------------|----------------------------------|
-//! | Postgres | `diesel_postgres` | [`diesel::PgPool`]    | [`diesel::AsyncPgConnection`]    |
-//! | MySQL    | `diesel_mysql`    | [`diesel::MysqlPool`] | [`diesel::AsyncMysqlConnection`] | //!
+//! | Database | Feature           | [`Pool`] Type          | [`Connection`] Deref                                         |
+//! |----------|-------------------|------------------------|--------------------------------------------------------------|
+//! | Postgres | `diesel_postgres` | [`diesel::PgPool`]     | [`diesel::AsyncPgConnection`]                                |
+//! | MySQL    | `diesel_mysql`    | [`diesel::MysqlPool`]  | [`diesel::AsyncMysqlConnection`]                             |
+//! | SQLite   | `diesel_sqlite`   | [`diesel::SqlitePool`] | [`diesel::SyncConnectionWrapper<diesel::SqliteConnection>>`] |
 //!
 //! See [`diesel`] for usage details.
 //!
@@ -243,7 +244,11 @@ pub use rocket;
 #[doc(inline)]
 pub use rocket::figment;
 
-#[cfg(any(feature = "diesel_postgres", feature = "diesel_mysql"))] pub mod diesel;
+#[cfg(any(
+    feature = "diesel_postgres",
+    feature = "diesel_mysql",
+    feature = "diesel_sqlite"
+))] pub mod diesel;
 #[cfg(feature = "deadpool_postgres")] pub use deadpool_postgres;
 #[cfg(feature = "deadpool_redis")] pub use deadpool_redis;
 #[cfg(feature = "mongodb")] pub use mongodb;

--- a/contrib/db_pools/lib/src/pool.rs
+++ b/contrib/db_pools/lib/src/pool.rs
@@ -192,6 +192,15 @@ mod deadpool_postgres {
         }
     }
 
+    #[cfg(feature = "diesel_sqlite")]
+    impl DeadManager for AsyncDieselConnectionManager<
+        diesel_async::sync_connection_wrapper::SyncConnectionWrapper::<diesel::SqliteConnection>
+    > {
+        fn new(config: &Config) -> Result<Self, Self::Error> {
+            Ok(Self::new(config.url.as_str()))
+        }
+    }
+
     #[rocket::async_trait]
     impl<M: DeadManager, C: From<Object<M>>> crate::Pool for Pool<M, C>
         where M::Type: Send, C: Send + Sync + 'static, M::Error: std::error::Error

--- a/examples/databases/src/diesel_mysql.rs
+++ b/examples/databases/src/diesel_mysql.rs
@@ -37,7 +37,7 @@ diesel::table! {
 async fn create(mut db: Connection<Db>, mut post: Json<Post>) -> Result<Created<Json<Post>>> {
     diesel::define_sql_function!(fn last_insert_id() -> BigInt);
 
-    let post = db.transaction(|mut conn| Box::pin(async move {
+    let post = db.transaction(async |mut conn| {
         diesel::insert_into(posts::table)
             .values(&*post)
             .execute(&mut conn)
@@ -49,7 +49,7 @@ async fn create(mut db: Connection<Db>, mut post: Json<Post>) -> Result<Created<
             .await?);
 
         Ok::<_, diesel::result::Error>(post)
-    })).await?;
+    }).await?;
 
     Ok(Created::new("/").body(post))
 }


### PR DESCRIPTION
This updates diesel and diesel-async to the newest versions. This requires minor changes:

* deadpool must be bumped. If you don't like this, you can avoid it by fixing diesel-async at 0.7.4.
* The diesel transaction call must be changed because a type changed from `FnOnce<Box<Pin<Future>>>` to `Future`. For an explanation of this, see [the diesel-async 0.9 release notes](https://github.com/diesel-rs/diesel_async/releases/tag/v0.9.0) or [this Mastodon discussion](https://mastodon.social/@mcc/117090120913503399). If you don't like this ,yo ucan avoid it by fixing disel-async at 0.8.

This patch rests atop my existing PR https://github.com/rwf2/Rocket/pull/2970 . I hope that's OK. It is probably possible to rebase 2c18c without #2970 (but I'd rather you accepted #2970, as it's minor and benign).

I tested this patch successfully with `test.sh --core`, `test.sh --examples`, and my own third-party app which makes sense of async diesel in the db pool.