### PR TITLE
Correct docs to reflect new log_level names in post-tracing Rocket

### DIFF
--- a/docs/guide/03-getting-started.md
+++ b/docs/guide/03-getting-started.md
@@ -92,7 +92,7 @@ run`. You should see the following:
    >> limits: [..]
    >> tls: disabled
    >> temp dir: /tmp
-   >> log level: normal
+   >> log level: info
    >> cli colors: true
 🛰  Routes:
    >> (index) GET /

--- a/docs/guide/04-overview.md
+++ b/docs/guide/04-overview.md
@@ -176,7 +176,7 @@ Running the application, the console shows:
    >> limits: [..]
    >> tls: disabled
    >> temp dir: /tmp
-   >> log level: normal
+   >> log level: info
    >> cli colors: true
 🛰  Routes:
    >> (world) GET /hello/world

--- a/docs/guide/10-configuration.md
+++ b/docs/guide/10-configuration.md
@@ -21,24 +21,24 @@ is configured with. This means that no matter which configuration provider
 Rocket is asked to use, it must be able to read the following configuration
 values:
 
-| key                  | kind               | description                                     | debug/release default         |
-|----------------------|--------------------|-------------------------------------------------|-------------------------------|
-| `address`            | `IpAddr`           | IP address to serve on.                         | `127.0.0.1`                   |
-| `port`               | `u16`              | Port to serve on.                               | `8000`                        |
-| `workers`*           | `usize`            | Number of threads to use for executing futures. | cpu core count                |
-| `max_blocking`*      | `usize`            | Limit on threads to start for blocking tasks.   | `512`                         |
-| `ident`              | `string`, `false`  | If and how to identify via the `Server` header. | `"Rocket"`                    |
-| `ip_header`          | `string`, `false`  | IP header to inspect to get [client's real IP]. | `"X-Real-IP"`                 |
-| `proxy_proto_header` | `string`, `false`  | Header identifying [client to proxy protocol].  | `None`                        |
-| `keep_alive`         | `u32`              | Keep-alive timeout seconds; disabled when `0`.  | `5`                           |
-| `log_level`          | [`LogLevel`]       | Max level to log. (off/normal/debug/critical)   | `normal`/`critical`           |
-| `cli_colors`         | [`CliColors`]      | Whether to use colors and emoji when logging.   | `"auto"`                      |
-| `secret_key`         | [`SecretKey`]      | Secret key for signing and encrypting values.   | `None`                        |
-| `tls`                | [`TlsConfig`]      | TLS configuration, if any.                      | `None`                        |
-| `limits`             | [`Limits`]         | Streaming read size limits.                     | [`Limits::default()`]         |
-| `limits.$name`       | `&str`/`uint`      | Read limit for `$name`.                         | form = "32KiB"                |
-| `ctrlc`              | `bool`             | Whether `ctrl-c` initiates a server shutdown.   | `true`                        |
-| `shutdown`*          | [`ShutdownConfig`] | Graceful shutdown configuration.                | [`ShutdownConfig::default()`] |
+| key                  | kind               | description                                           | debug/release default         |
+|----------------------|--------------------|-------------------------------------------------------|-------------------------------|
+| `address`            | `IpAddr`           | IP address to serve on.                               | `127.0.0.1`                   |
+| `port`               | `u16`              | Port to serve on.                                     | `8000`                        |
+| `workers`*           | `usize`            | Number of threads to use for executing futures.       | cpu core count                |
+| `max_blocking`*      | `usize`            | Limit on threads to start for blocking tasks.         | `512`                         |
+| `ident`              | `string`, `false`  | If and how to identify via the `Server` header.       | `"Rocket"`                    |
+| `ip_header`          | `string`, `false`  | IP header to inspect to get [client's real IP].       | `"X-Real-IP"`                 |
+| `proxy_proto_header` | `string`, `false`  | Header identifying [client to proxy protocol].        | `None`                        |
+| `keep_alive`         | `u32`              | Keep-alive timeout seconds; disabled when `0`.        | `5`                           |
+| `log_level`          | [`LogLevel`]       | Max level to log. (off/error/warn/info/debug/trace)   | `info`/`error`                |
+| `cli_colors`         | [`CliColors`]      | Whether to use colors and emoji when logging.         | `"auto"`                      |
+| `secret_key`         | [`SecretKey`]      | Secret key for signing and encrypting values.         | `None`                        |
+| `tls`                | [`TlsConfig`]      | TLS configuration, if any.                            | `None`                        |
+| `limits`             | [`Limits`]         | Streaming read size limits.                           | [`Limits::default()`]         |
+| `limits.$name`       | `&str`/`uint`      | Read limit for `$name`.                               | form = "32KiB"                |
+| `ctrlc`              | `bool`             | Whether `ctrl-c` initiates a server shutdown.         | `true`                        |
+| `shutdown`*          | [`ShutdownConfig`] | Graceful shutdown configuration.                      | [`ShutdownConfig::default()`] |
 
 
 <small>* Note: the `workers`, `max_blocking`, and `shutdown.force` configuration
@@ -95,7 +95,7 @@ sources in ascending priority order:
 The selected profile is the value of the `ROCKET_PROFILE` environment variable,
 or if it is not set, "debug" when compiled in debug mode and "release" when
 compiled in release mode. With the exception of `log_level`, which changes from
-`normal` in debug to `critical` in release, all of the default configuration
+`info` in debug to `error` in release, all of the default configuration
 values are the same in all profiles. What's more, all configuration values
 _have_ defaults, so no configuration is needed to get started.
 
@@ -158,7 +158,7 @@ keep_alive = 5
 ident = "Rocket"
 ip_header = "X-Real-IP" # set to `false` to disable
 proxy_proto_header = false # set to `false` (the default) to disable
-log_level = "normal"
+log_level = "info"
 temp_dir = "/tmp"
 cli_colors = true
 # NOTE: Don't (!) use this key! Generate your own and keep it private!

--- a/docs/guide/11-deploying.md
+++ b/docs/guide/11-deploying.md
@@ -323,8 +323,8 @@ environment, we provide only the following general guidelines:
 
   * **Enable debug logging if the application misbehaves.**
 
-    The default log level in `--release` (the release profile) is `critical`.
+    The default log level in `--release` (the release profile) is `error`.
     This level may omit messages helpful in understanding application
-    misbehavior. To reenable those messages, set `ROCKET_LOG_LEVEL=debug`.
+    misbehavior. To enable all messages, set `ROCKET_LOG_LEVEL=debug`.
 
 [configuration profile]: ../configuration/#profiles


### PR DESCRIPTION
In 0.5.1, the log levels are "off", "normal", "debug", and "critical". In current `master`, due to adoption of the `tracing` crate, they are "off", "error", "warn", "info", "debug", "trace", or 0-5. This is not currently reflected in the documentation. (Which is bad, because if you check out `master` and follow the documentation currently in the `docs/` folder, you will set your log_level to "normal" or "critical", and the program will fail to boot.) Patch addresses this.

Quirks of patch:

- After switching to tracing, it appears the numbers 0-5 are also allowed as values for `log_level`. I don't know what strings these correspond to, so I didn't try to document them. I will fix this if you ask.
- I changed one line to fix an ambiguity caused by the fact `info` and `debug` are now separate log levels.